### PR TITLE
Add mock_repo flag to Git init to allow svn-only modules to be tarred…

### DIFF
--- a/dls_ade/dls_tar_module.py
+++ b/dls_ade/dls_tar_module.py
@@ -122,7 +122,7 @@ def main():
     
     build.set_area(args.area)
 
-    git = vcs_git.Git(args.module_name, args)
+    git = vcs_git.Git(args.module_name, args, mock_repo=release_dir)
     git.set_version(args.release)
 
     build.submit(git)

--- a/dls_ade/vcs_git.py
+++ b/dls_ade/vcs_git.py
@@ -552,21 +552,27 @@ class Git(BaseVCS):
 
     """
 
-    def __init__(self, module, options):
+    def __init__(self, module, options, mock_repo=""):
 
         self._module = module
         self.area = options.area
-
-        server_repo_path = pathf.dev_module_path(self._module, self.area)
-
-        if not is_server_repo(server_repo_path):
-            raise VCSGitError('repo not found on gitolite server')
-
-        repo_dir = tempfile.mkdtemp(suffix="_" + self._module.replace("/", "_"))
-        self._remote_repo = os.path.join(GIT_SSH_ROOT, server_repo_path)
-
-        self.client = git.Repo.clone_from(self._remote_repo, repo_dir)
         self._version = None
+        self.mock_repo = mock_repo
+
+        if not self.mock_repo:
+
+            server_repo_path = pathf.dev_module_path(self._module, self.area)
+            if not is_server_repo(server_repo_path):
+                raise VCSGitError('repo not found on gitolite server')
+
+            repo_dir = tempfile.mkdtemp(suffix="_" + self._module.replace("/", "_"))
+            self._remote_repo = os.path.join(GIT_SSH_ROOT, server_repo_path)
+
+            self.client = git.Repo.clone_from(self._remote_repo, repo_dir)
+        else:
+            self._remote_repo = mock_repo
+
+
 
     @property
     def vcs_type(self):
@@ -660,7 +666,7 @@ class Git(BaseVCS):
             version(str): Version release tag
 
         """
-        if not self.check_version_exists(version):
+        if not self.mock_repo and not self.check_version_exists(version):
             raise VCSGitError('version does not exist')
         self._version = version
 

--- a/dls_ade/vcs_git_test.py
+++ b/dls_ade/vcs_git_test.py
@@ -1084,6 +1084,12 @@ class GitClassInitTest(unittest.TestCase):
         with self.assertRaises(Exception):
             vcs_git.Git(1, 2)
 
+    @patch('dls_ade.vcs_git.tempfile.mkdtemp')
+    @patch('dls_ade.vcs_git.git.Repo.clone_from')
+    def test_given_mock_repo_then_set_mock_remote(self, _1, _2):
+
+        git = vcs_git.Git('dummy', FakeOptions(), mock_repo='dummy/2-1')
+        self.assertEqual('dummy/2-1', git._remote_repo)
 
     @patch('dls_ade.vcs_git.tempfile.mkdtemp')
     @patch('dls_ade.vcs_git.git.Repo.clone_from')
@@ -1406,6 +1412,15 @@ class GitSettersTest(unittest.TestCase):
 
         with self.assertRaises(vcs_git.VCSGitError):
             self.vcs.version
+
+    @patch('dls_ade.vcs_git.Git.check_version_exists', return_value=True)
+    def test_given_mock_repo_then_set_return_version(self, mcheck):
+
+        version = '0-1'
+        self.vcs.mock_repo = "/path/to/module/release"
+        self.vcs.set_version(version)
+
+        self.assertEqual(self.vcs.version, version)
 
     @patch('dls_ade.vcs_git.Git.check_version_exists', return_value=True)
     def test_given_vcs_when_version_set_return_version(self, mcheck):


### PR DESCRIPTION
… and untarred