### PR TITLE
CA Repeater

### DIFF
--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -35,7 +35,8 @@ DLS_EPICS_RELEASE=${_epics}
 source /dls_sw/etc/profile
 OS_VERSION=$(lsb_release -sr | cut -d. -f1)
 # Ensure CA Repeater is running (will close itself if already running)
-caRepeater &
+EPICS_CA_SERVER_PORT=5064 EPICS_CA_REPEATER_PORT=5065 caRepeater &
+EPICS_CA_SERVER_PORT=6064 EPICS_CA_REPEATER_PORT=6065 caRepeater &
 
 case "$OS_VERSION" in
     [45])

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -111,18 +111,19 @@ esac
 # Build
 error_log=${_build_name}.err
 build_log=${_build_name}.log
+status_log=${_build_name}.sta
 {
     {
         make clean && make
-        echo $? >${_build_name}.sta
+        echo $? >$status_log
 
         # This is a bit of a hack to only install in production builds
-        if  [[ "$build_dir" =~ "/prod/" && "$(cat ${_build_name}.sta)" == "0" ]] ; then
+        if  [[ "$build_dir" =~ "/prod/" && "$(cat $status_log)" == "0" ]] ; then
             make install
-            echo $? >${_build_name}.sta
+            echo $? >$status_log
 
             # If successful, run make-defaults
-            if (( ! $(cat ${_build_name}.sta) )) ; then
+            if (( ! $(cat $status_log) )) ; then
                 TOOLS_BUILD=/dls_sw/prod/etc/build/tools_build
                 $TOOLS_BUILD/make-defaults $TOOLS_DIR $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
             fi
@@ -134,7 +135,7 @@ build_log=${_build_name}.log
     # Redirect '3' (saved STDOUT from above) to build log
 } 1>$build_log 3>&1  # redirect STDOUT and STDERR to build log
 
-if (( $(cat ${_build_name}.sta) != 0 )) ; then
+if (( $(cat $status_log) != 0 )) ; then
     ReportFailure $error_log
 elif (( $(stat -c%s $error_log) != 0 )) ; then
     cat $error_log | mail -s "Build Errors: $_area $_module $_version"         $_email

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -127,9 +127,12 @@ build_log=${_build_name}.log
                 $TOOLS_BUILD/make-defaults $TOOLS_DIR $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
             fi
         fi
-    } 4>&1 1>&3 2>&4 |
-    tee $error_log
-} >$build_log 3>&1
+        # Redirect '2' (STDERR) to '1' (STDOUT) so it can be piped to tee
+        # Redirect '1' (STDOUT) to '3' (a new file descriptor) to save it for later
+    } 2>&1 1>&3 | tee $error_log  # copy STDERR to error log
+    # Redirect '1' (STDOUT) of tee (STDERR from above) to build log
+    # Redirect '3' (saved STDOUT from above) to build log
+} 1>$build_log 3>&1  # redirect STDOUT and STDERR to build log
 
 if (( $(cat ${_build_name}.sta) != 0 )) ; then
     ReportFailure $error_log

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -34,6 +34,8 @@ ReportFailure()
 DLS_EPICS_RELEASE=${_epics}
 source /dls_sw/etc/profile
 OS_VERSION=$(lsb_release -sr | cut -d. -f1)
+# Ensure CA Repeater is running (will close itself if already running)
+caRepeater &
 
 case "$OS_VERSION" in
     [45])


### PR DESCRIPTION
This pull request fixes an unusual bug which causes the build server to hang.

If the `caRepeater` process isn't running when a `ca*` command is run (e.g. `caput`), [it is started automatically](http://www.aps.anl.gov/epics/base/R3-14/12-docs/CAref.html#Repeater). Because `caRepeater` is a 'server' process, it doesn't die with its parent and is orphaned. The `tee` [here](https://github.com/dls-controls/dls_ade/blob/a394822446a52bb7760d58964f829c31526bf6da/dls_ade/dlsbuild_scripts/Linux/python.sh#L136) waits for `caRepeater` to end indefinitely, and hangs the build server. The proposed fix is to make sure `caRepeater` is running before the build starts.
I've also tidied up and commented the file descriptor redirection to make it easier to understand.

If this pull request is merged I'll port it to the current version of dls_release (on gitolite?)