### PR TITLE
Add RHEL7 option to dls_release

### DIFF
--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -110,7 +110,7 @@ def make_parser():
         dest="rhel_version",
         help="change the rhel version of the build. This will determine which "
         "build server your job is build on for non-epics modules. Default "
-        "is from /etc/redhat-release. Can be 6")
+        "is from /etc/redhat-release. Can be 6 or 7")
     group.add_argument(
         "-w", "--windows", action="store", dest="windows", type=str,
         help="Release the module or IOC only for the Windows version. "

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -28,7 +28,8 @@ windows_root_dir = "W:/"
 # A list of build servers and the EPICS releases they support
 build_servers = {
     "Linux": {
-        "redhat6-x86_64" : ["R3.14.12.3"]
+        "redhat6-x86_64": ["R3.14.12.3"],
+        "redhat7-x86_64": ["R3.14.12.6"]
     },
     "Windows": {
         "windows6-x86"   : ["R3.14.12.3"],
@@ -45,6 +46,7 @@ def epics_servers(os, epics):
 
 server_shortcut = {
     "6": "redhat6-x86_64",
+    "7": "redhat7-x86_64",
     "32": "windows6-x86",
     "64": "windows6-AMD64"}
 


### PR DESCRIPTION
Add RHEL7 server entry to dlsbuild, so passing 7 as --rhel-version will work
RHEL7 EPICS version set as latest version (R3.14.12.6) of R3.14.12 series