### PR TITLE
Use Matlab area in Git

### DIFF
--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -175,7 +175,7 @@ def check_parsed_arguments_valid(args,  parser):
             * <args.area> area not supported by git
 
     """
-    git_supported_areas = ['support', 'ioc', 'python', 'tools', 'targetOS']
+    git_supported_areas = ['support', 'ioc', 'python', 'matlab', 'tools', 'targetOS']
     if not args.module_name:
         parser.error("Module name not specified")
         logging.debug(args.module_name)

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -312,17 +312,15 @@ class TestCheckParsedOptionsValid(unittest.TestCase):
 
         self.mock_error.assert_called_once_with(expected_error_message)
 
-    def test_given_git_and_matlab_area_else_good_options_then_raise_error(self):
+    def test_given_git_and_matlab_area_else_good_options_then_error_not_raised(self):
 
         self.args.module_name = "module"
         self.args.release = "version"
         self.args.area = "matlab"
 
-        expected_error_message = self.args.area + " area not supported by git"
-
         dls_release.check_parsed_arguments_valid(self.args, self.parser)
 
-        self.mock_error.assert_called_once_with(expected_error_message)
+        self.assertFalse(self.mock_error.call_count)
 
     def test_given_git_and_etc_area_else_good_options_then_raise_error(self):
 

--- a/dls_ade/dlsbuild_scripts/Linux/matlab.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/matlab.sh
@@ -62,9 +62,13 @@ fi
 
 cd $_version || ReportFailure "Can not cd to $_version"
 
-# Write some history (Kludging a definition of SVN_ROOT)
-SVN_ROOT=http://serv0002.cs.diamond.ac.uk/repos/controls \
-   dls-logs-since-release.py -r --area=$_area $_module > DEVHISTORY.autogen
+if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
+    git cat-file -p HEAD:configure/RELEASE > configure/RELEASE.vcs
+else
+    # Write some history (Kludging a definition of SVN_ROOT)
+    SVN_ROOT=http://serv0002.cs.diamond.ac.uk/repos/controls \
+      dls-logs-since-release.py -r --area=$_area $_module > DEVHISTORY.autogen
+fi
 
 # Build
 error_log=${_build_name}.err

--- a/dls_ade/get_module_creator.py
+++ b/dls_ade/get_module_creator.py
@@ -76,6 +76,9 @@ def get_module_creator(module_name, area="support", fullname=False):
     elif area == "tools":
         return mc.ModuleCreator(module_name, area, mt.ModuleTemplateTools)
 
+    elif area == "matlab":
+        return mc.ModuleCreator(module_name, area, mt.ModuleTemplateMatlab)
+
     else:
         raise ParsingError("Don't know how to make a module of type: " + area)
 

--- a/dls_ade/module_template.py
+++ b/dls_ade/module_template.py
@@ -452,3 +452,40 @@ class ModuleTemplateIOCBL(ModuleTemplateWithApps):
         message = message.format(**message_dict)
 
         print(message)
+
+
+class ModuleTemplateMatlab(ModuleTemplate):
+    """Class for the management of the creation of new Matlab modules.
+
+    For this class to work properly, the following template arguments must be\
+    specified upon initialisation:
+
+        - module_name
+        - module_path
+        - user_login
+
+    """
+
+    def __init__(self, template_args, additional_required_args=None):
+        """Initialise template args and default template files."""
+
+        required_args = ['module_name', 'module_path', 'user_login']
+
+        if additional_required_args is not None:
+            required_args += additional_required_args
+
+        super(ModuleTemplateMatlab, self).__init__(
+                template_args,
+                required_args
+        )
+
+        self._set_template_files_from_area("default")
+
+    def print_message(self):
+        message_dict = {'module_path': self._template_args['module_path']}
+
+        message = ("\nPlease add your matlab files to the {module_path:s}"
+                   "\ndirectory and commit them before releasing.")
+        message = message.format(**message_dict)
+
+        print(message)


### PR DESCRIPTION
This addresses https://github.com/dls-controls/dls_ade/issues/50. I think I caught all the places in the code where the is specific handling of the module area, so Matlab and Git should work for all the dls scripts now.