### PR TITLE
CGP-7: missing tags

### DIFF
--- a/dls_ade/dlsbuild_scripts/Linux/matlab.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/matlab.sh
@@ -38,12 +38,12 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
         ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
-        git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
     elif (( $(git status -uno --porcelain | wc -l) != 0)) ; then
         ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
     fi

--- a/dls_ade/dlsbuild_scripts/Linux/matlab.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/matlab.sh
@@ -38,8 +38,8 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version &&  git checkout $_version ) || ReportFailure "Can not checkout $_version"        
+        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
         git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -59,12 +59,12 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
         ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
-        git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
     elif [[ (( $(git status -uno --porcelain | wc -l) != 0 )) ]]; then
         ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
     fi

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -59,8 +59,8 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version &&  git checkout $_version ) || ReportFailure "Can not checkout $_version"        
+        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
         git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"

--- a/dls_ade/dlsbuild_scripts/Linux/support.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/support.sh
@@ -41,12 +41,12 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
         ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
-        git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
+        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
     elif (( $(git status -uno --porcelain | grep -Ev "M.*configure/RELEASE$" | wc -l) != 0 )) ; then
         ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
     fi

--- a/dls_ade/dlsbuild_scripts/Linux/support.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/support.sh
@@ -41,8 +41,8 @@ cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
-        git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
-        ( cd $_version &&  git checkout $_version ) || ReportFailure "Can not checkout $_version"        
+        git clone --depth=10 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
         git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -84,12 +84,12 @@ set -o xtrace
 
         if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
             if [ ! -d $_version ]; then
-                git clone --depth=10 $_git_dir $_version
+                git clone --depth=100 $_git_dir $_version
                 ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )
             elif [ "$_force" == "true" ] ; then
                 rm -rf $_version
-                git clone $_git_dir $_version
-                ( cd $_version && git checkout $_version )
+                git clone --depth=100 $_git_dir $_version
+                ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )
             elif (( $(git status -uno --porcelain | grep -Ev "M.*configure/RELEASE$" | wc -l) != 0)) ; then
                 ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
             fi

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -84,8 +84,8 @@ set -o xtrace
 
         if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
             if [ ! -d $_version ]; then
-                git clone --depth=100 $_git_dir $_version
-                ( cd $_version &&  git checkout $_version )
+                git clone --depth=10 $_git_dir $_version
+                ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )
             elif [ "$_force" == "true" ] ; then
                 rm -rf $_version
                 git clone $_git_dir $_version

--- a/dls_ade/gitserver.py
+++ b/dls_ade/gitserver.py
@@ -114,7 +114,7 @@ class GitServer(object):
         repo_dir = tempfile.mkdtemp(suffix="_" + module.replace("/", "_"))
         repo = git.Repo.clone_from(os.path.join(self.clone_url,
                                                 self.get_clone_path(source)),
-                                   repo_dir, depth=1)
+                                   repo_dir)
 
         git_inst = Git(module, area, self, repo)
 

--- a/dls_ade/gitserver_test.py
+++ b/dls_ade/gitserver_test.py
@@ -139,7 +139,7 @@ class TempCloneTest(unittest.TestCase):
 
         mock_mkdtemp.assert_called_once_with(suffix="_test_module")
         mock_clone_from.assert_called_once_with(
-            "test@url.ac.uk/controls/area/test_module", "tempdir", depth=1)
+            "test@url.ac.uk/controls/area/test_module", "tempdir")
 
     @patch('dls_ade.gitserver.GitServer.get_clone_path',
            return_value="controls/ioc/domain/test_module")
@@ -156,8 +156,7 @@ class TempCloneTest(unittest.TestCase):
 
         mock_mkdtemp.assert_called_once_with(suffix="_domain_test_module")
         mock_clone_from.assert_called_once_with(
-            "test@url.ac.uk/controls/ioc/domain/test_module", "tempdir",
-            depth=1)
+            "test@url.ac.uk/controls/ioc/domain/test_module", "tempdir")
 
 
 class CloneMultiTest(unittest.TestCase):


### PR DESCRIPTION
This is a fix to the issue where build server shallow clones are missing: https://jira.diamond.ac.uk/browse/CGP-7

Basically we shallow-fetch the relevant version tag in the build script as described here: https://stackoverflow.com/questions/26617862/git-shallow-fetch-of-a-new-tag 