### PR TITLE
Use the first version of Python found in OS tools dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean:
 	-find -name '*.pyc' -exec rm {} \;
 
 install: dist
+	mkdir -p $(PREFIX)/lib/python2.7/site-packages
 	$(PYTHON) setup.py easy_install -m \
 		--record=installed.files \
 		--prefix $(PREFIX) dist/*.egg

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -48,7 +48,7 @@ case "$OS_VERSION" in
     *)
         build_dir=${_build_dir}/RHEL${OS_VERSION}-$(uname -m)/${_module}
         PREFIX=${build_dir}/${_version}/prefix
-        PYTHON=/dls_sw/prod/tools/RHEL6-x86_64/Python/2-7-3/prefix/bin/python2.7
+        PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}/Python/*/prefix/bin/python2.7
         INSTALL_DIR=${PREFIX}/lib/python2.7/site-packages
         TOOLS_DIR=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)
 esac

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -48,7 +48,7 @@ case "$OS_VERSION" in
     *)
         build_dir=${_build_dir}/RHEL${OS_VERSION}-$(uname -m)/${_module}
         PREFIX=${build_dir}/${_version}/prefix
-        PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}/Python/*/prefix/bin/python2.7
+        PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)/Python/*/prefix/bin/python2.7
         INSTALL_DIR=${PREFIX}/lib/python2.7/site-packages
         TOOLS_DIR=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)
 esac

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -45,12 +45,15 @@ case "$OS_VERSION" in
         PYTHON=${PREFIX}/bin/python2.6
         INSTALL_DIR=${PREFIX}/lib/python2.6/site-packages
         ;;
-    *)
+    [67])
         build_dir=${_build_dir}/RHEL${OS_VERSION}-$(uname -m)/${_module}
         PREFIX=${build_dir}/${_version}/prefix
-        PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)/Python/*/prefix/bin/python2.7
+        PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)/defaults/bin/dls-python
         INSTALL_DIR=${PREFIX}/lib/python2.7/site-packages
         TOOLS_DIR=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)
+        ;;
+       *)
+        ReportFailure "OS Version ${OS_VERSION} not handled"
 esac
 
 # Checkout module

--- a/dls_ade/module_templates/python/Makefile
+++ b/dls_ade/module_templates/python/Makefile
@@ -22,6 +22,7 @@ clean:
 
 # Install the built egg and keep track of what was installed
 install: dist
+	mkdir -p $(PREFIX)/lib/python2.7/site-packages
 	$(PYTHON) setup.py easy_install -m \
 		--record=installed.files \
 		--prefix=$(PREFIX) dist/*.egg


### PR DESCRIPTION
Python modules are being built with RHEL6 Python even on RHEL7, and this is ending up in the shebang of executable binaries.