### PR TITLE
CGP-8 logging and errors

### DIFF
--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -24,109 +24,70 @@
 
 ReportFailure()
 {
-    cat "$TEMP_LOG" |  mail -s "Build Errors: $_area $_module $_version" $_email
+    { [ -f "$1" ] && cat $1 || echo $*; } |
+    mail -s "Build Errors: $_area $_module $_version" $_email
     exit 2
 }
 
-TEMP_LOG="$(mktemp)"
-trap ReportFailure ERR
-trap 'rm -f "$TEMP_LOG"' EXIT
-set -o errexit
-set -o xtrace
 
-{
-    # Set up environment
-    DLS_EPICS_RELEASE=${_epics}
-    source /dls_sw/etc/profile
-    export SVN_ROOT=http://serv0002.cs.diamond.ac.uk/repos/controls
+# Set up environment
+DLS_EPICS_RELEASE=${_epics}
+source /dls_sw/etc/profile
 
-    work_tar_dir=/dls_sw/work/targetOS/tar-files
-    prod_tar_dir=/dls_sw/prod/targetOS/tar-files
-    if [ ! -z "$(ls $work_tar_dir/)" -a -w $prod_tar_dir ]; then
-        mv $work_tar_dir/* $prod_tar_dir || { echo Can not move tar files; exit 1; }
-    fi
+work_tar_dir=/dls_sw/work/targetOS/tar-files
+prod_tar_dir=/dls_sw/prod/targetOS/tar-files
+if [ ! -z "$(ls $work_tar_dir/)" -a -w $prod_tar_dir ]; then
+    mv $work_tar_dir/* $prod_tar_dir || ReportFailure "Can not move tar files"
+fi
 
-    # Ensure there is a architecture dependent build directory available
-    OS_VERSION=$(lsb_release -sr | cut -d. -f1)
+# Ensure there is a architecture dependent build directory available
+OS_VERSION=$(lsb_release -sr | cut -d. -f1)
 
-    if (( $OS_VERSION < 6 )) ; then
-        build_dir=$_build_dir/RHEL$OS_VERSION
 
-        mkdir -p $build_dir
-        cd $build_dir
+TOOLS_BUILD=/dls_sw/prod/etc/build/tools_build
+TOOLS_ROOT=/dls_sw/prod/tools/RHEL$OS_VERSION-$(uname -m)
+build_dir=$_build_dir/RHEL$OS_VERSION-$(uname -m)
 
-        # Checkout build program - always from RHEL5 directory in branches
-        if [ ! -d build_scripts ]; then
-            svn checkout -q --depth=files $SVN_ROOT/diamond/branches/build_scripts/RHEL5 build_scripts
-        else
-            svn switch --depth=files $SVN_ROOT/diamond/branches/build_scripts/RHEL5 build_scripts 
-        fi
+# Checkout module
+mkdir -p $build_dir/${_module} || ReportFailure "Can not mkdir $build_dir/${_module}"
+cd $build_dir/${_module} || ReportFailure "Can not cd to $build_dir/${_module}"
 
-        cd build_scripts
+if [ ! -d $_version ]; then
+    git clone --depth=10 $_git_dir $_version || ReportFailure "Can not clone  $_git_dir"
+    ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
+elif [ "$_force" == "true" ] ; then
+    rm -rf $_version                            || ReportFailure "Can not rm $_version"
+    git clone $_git_dir $_version               || ReportFailure "Can not clone  $_git_dir"
+    ( cd $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
+elif (( $(git status -uno --porcelain | grep -Ev "M.*configure/RELEASE$" | wc -l) != 0)) ; then
+    ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
+fi
 
-        [ "$_force" == "true" ] && rm -rf $_module
+# Add the ROOT definition to the RELEASE file
+release_file="$_version"/configure/RELEASE
 
-        if [ ! -d $_module ]; then
-            svn checkout -q $_svn_dir $_module
-        else
-            svn switch $_svn_dir $_module
-        fi
+# The following is for short term compatibility purposes
+[ ! -f "$release_file" ] && release_file="$_version"/RELEASE
 
-        ./build_program $_module
-    else
-        TOOLS_BUILD=/dls_sw/prod/etc/build/tools_build
-        TOOLS_ROOT=/dls_sw/prod/tools/RHEL$OS_VERSION-$(uname -m)
-        build_dir=$_build_dir/RHEL$OS_VERSION-$(uname -m)
-
-        # Checkout module
-        mkdir -p $build_dir/${_module}
-        cd $build_dir/${_module}
-
-        if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
-            if [ ! -d $_version ]; then
-                git clone --depth=10 $_git_dir $_version
-                ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )
-            elif [ "$_force" == "true" ] ; then
-                rm -rf $_version
-                git clone $_git_dir $_version
-                ( cd $_version && git checkout $_version )
-            elif (( $(git status -uno --porcelain | grep -Ev "M.*configure/RELEASE$" | wc -l) != 0)) ; then
-                ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
-            fi
-        elif [[ "${_git_dir:-undefined}" == "undefined" ]] ; then
-            if [ ! -d $_version ]; then
-                svn checkout -q "$_svn_dir" "$_version"
-            elif [ "$_force" == "true" ] ; then
-                rm -rf $_version
-                svn checkout -q "$_svn_dir" "$_version"
-            elif (( $(svn status -qu "$_version" | grep -Ev "^M.*configure/RELEASE$" | wc -l) != 1 )) ; then
-                ReportFailure "Directory $build_dir/$_version not up to date with $_svn_dir"
-            fi
-        else 
-            ReportFailure "both _git_dir and _svn_dir are defined; unclear which to use"
-        fi
-
-        # Add the ROOT definition to the RELEASE file
-        release_file="$_version"/configure/RELEASE
-
-        # The following is for short term compatibility purposes
-        [ ! -f "$release_file" ] && release_file="$_version"/RELEASE
-
-        if [ -f "$release_file" ] ; then
-            if (( ! $(grep -c '^( *ROOT| *TOOLS_SUPPORT)' "$release_file") )) ; then
-                sed -i "1i\
+if [ -f "$release_file" ] ; then
+    if (( ! $(grep -c '^( *ROOT| *TOOLS_SUPPORT)' "$release_file") )) ; then
+        sed -i "1i\
 TOOLS_SUPPORT=$TOOLS_ROOT" "$release_file"
-            else
-                sed -i \
-                    -e 's,^ *ROOT *=.*$,ROOT='"$TOOLS_ROOT," \
-                    -e 's,^ *TOOLS_SUPPORT *=.*$,TOOLS_SUPPORT='"$TOOLS_ROOT," \
-                    "$release_file"
-            fi
-        fi
-
-        $TOOLS_BUILD/build_program -n $_build_name ${_version}
-
-        $TOOLS_BUILD/make-defaults $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
+    else
+        sed -i \
+            -e 's,^ *ROOT *=.*$,ROOT='"$TOOLS_ROOT," \
+            -e 's,^ *TOOLS_SUPPORT *=.*$,TOOLS_SUPPORT='"$TOOLS_ROOT," \
+            "$release_file"
     fi
+fi
 
-} > "$TEMP_LOG" 2>&1
+# Build
+$TOOLS_BUILD/build_program -n $_build_name ${_version}
+
+if (( $(cat ${_build_name}.sta) != 0 )) ; then
+    ReportFailure $error_log
+elif (( $(stat -c%s ${_build_name}.err) != 0 )) ; then
+    cat ${_build_name}.err | mail -s "Build Errors: $_area $_module $_version" $_email
+fi
+
+$TOOLS_BUILD/make-defaults $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -84,10 +84,9 @@ fi
 # Build
 $TOOLS_BUILD/build_program -n $_build_name ${_version}
 
-if (( $(cat ${_build_name}.sta) != 0 )) ; then
-    ReportFailure $error_log
-elif (( $(stat -c%s ${_build_name}.err) != 0 )) ; then
-    cat ${_build_name}.err | mail -s "Build Errors: $_area $_module $_version" $_email
+if (( $(cat ${_version}/${_build_name}.sta) != 0 )) ; then
+    ReportFailure ${_version}/${_build_name}.log
 fi
 
 $TOOLS_BUILD/make-defaults $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
+

--- a/dls_ade/gitserver_test.py
+++ b/dls_ade/gitserver_test.py
@@ -139,7 +139,7 @@ class TempCloneTest(unittest.TestCase):
 
         mock_mkdtemp.assert_called_once_with(suffix="_test_module")
         mock_clone_from.assert_called_once_with(
-            "test@url.ac.uk/controls/area/test_module", "tempdir", depth=1)
+            "test@url.ac.uk/controls/area/test_module", "tempdir")
 
     @patch('dls_ade.gitserver.GitServer.get_clone_path',
            return_value="controls/ioc/domain/test_module")
@@ -156,8 +156,7 @@ class TempCloneTest(unittest.TestCase):
 
         mock_mkdtemp.assert_called_once_with(suffix="_domain_test_module")
         mock_clone_from.assert_called_once_with(
-            "test@url.ac.uk/controls/ioc/domain/test_module", "tempdir",
-            depth=1)
+            "test@url.ac.uk/controls/ioc/domain/test_module", "tempdir")
 
 
 class CloneMultiTest(unittest.TestCase):


### PR DESCRIPTION
Re-work the tools.sh template build server script to handle and log errors in the same way as the other template scripts (for iocs, support modules, etc).

Fixes [JIRA ticket GCP-8](https://jira.diamond.ac.uk/browse/CGP-8)
