### PR TITLE
CGP-42 Don't create release tag if it doesn't exist

### DIFF
--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -413,9 +413,6 @@ def main():
     commit_msg = log_mess.format(module=module, version=version,
                                  message=args.message)
 
-    if not vcs.check_version_exists(version) and not args.test_only:
-        vcs.release_version(version, commit_msg)
-
     vcs.set_version(version)
 
     print(construct_info_message(module, args.branch, args.area, version,

--- a/dls_ade/vcs.py
+++ b/dls_ade/vcs.py
@@ -65,8 +65,3 @@ class BaseVCS(object):
         ''' Set the desired version number to release under '''
         raise NotImplementedError
 
-
-    @abc.abstractmethod
-    def release_version(self, version):
-        ''' Create release version/tag of module with specified version '''
-        raise NotImplementedError

--- a/dls_ade/vcs_git.py
+++ b/dls_ade/vcs_git.py
@@ -363,14 +363,6 @@ class Git(BaseVCS):
             raise VCSGitError('version does not exist')
         self._version = version
 
-    def release_version(self, version, message=""):
-
-        self.repo.create_tag(version, message=message)
-
-        origin = self.repo.remotes.origin
-        # This is equivalent to 'git push origin <tag_name>'
-        origin.push(version)
-
     def push_to_remote(self, remote_name="origin", branch_name="master"):
         """
         Pushes to the server path given by its remote name, on the given

--- a/dls_ade/vcs_git_test.py
+++ b/dls_ade/vcs_git_test.py
@@ -1133,13 +1133,6 @@ class GitSettersTest(unittest.TestCase):
 
         self.vcs.repo.remotes.origin.refs.__getitem__().checkout.assert_called_once_with(b=branch)
 
-    def test_given_version_then_create_tag_and_push(self):
-
-        self.vcs.release_version('1-0', message='Release 1-0')
-
-        self.vcs.repo.create_tag.assert_called_once_with('1-0', message='Release 1-0')
-        self.vcs.repo.remotes.origin.push.assert_called_once_with('1-0')
-
 
 class FakeTag(object):
     def __init__(self, name):


### PR DESCRIPTION
We do not want to have Git tags created when they do not exist. This removes the methods associated with that.