### PR TITLE
Fix print logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ variables DLSBUILD_ROOT_DIR and/or DLSBUILD_WIN_ROOT_DIR
   # Now see and/or run build script in
   # $HOME/test/work/etc/build/queue
 ```
+
+## Logging
+
+The dls_ade scripts produce log messages as they progress. Messages for the regular
+user is printed to stdout and further debug and info messages are logged to the DLS
+graylog system.
+A local debug log is also written to the users home dir: `$HOME/.dls_ade_debug.log`
+
+To review logs produced by the scripts for a given user, visit 
+https://graylog.diamond.ac.uk or
+https://graylog2.diamond.ac.uk 
+and search `package:dls_ade AND username:fedid` (replacing `fedid` for the users FedID)

--- a/dls_ade/dls_changes_since_release.py
+++ b/dls_ade/dls_changes_since_release.py
@@ -9,8 +9,7 @@ from dls_ade.argument_parser import ArgParser
 from dls_ade import path_functions as pathf
 from dls_ade import vcs_git
 from dls_ade import Server
-
-logging.basicConfig(level=logging.DEBUG)
+from dls_ade import logconfig
 
 usage = """
 Default <area> is 'support'.
@@ -32,7 +31,10 @@ def make_parser():
     return parser
 
 
-def main():
+def _main():
+    log = logging.getLogger(name="dls_ade")
+    usermsg = logging.getLogger(name="usermessages")
+    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
@@ -43,7 +45,7 @@ def main():
 
     module = args.module_name
     source = server.dev_module_path(module, args.area)
-    logging.debug(source)
+    log.debug(source)
 
     if server.is_server_repo(source):
         vcs = server.temp_clone(source)
@@ -52,25 +54,36 @@ def main():
         if releases:
             last_release_num = releases[-1]
         else:
-            print("No release has been done for " + module)
+            usermsg.info("No release has been done for {}".format(module))
             # return so last_release_num can't be referenced before assignment
             return 1
     else:
-        raise IOError(source + " does not exist on the repository.")
+        raise IOError("{} does not exist on the repository.".format(source))
 
     # Get a single log between last release and HEAD
     # If there is one, then changes have been made
     logs = list(vcs.repo.iter_commits(last_release_num + "..HEAD",
                                       max_count=1))
     if logs:
-        print("Changes have been made to " + module +
-              " since release " + last_release_num)
+        usermsg.info("Changes have been made to {module}"
+                     " since release {release}".format(module=module, release=last_release_num))
     else:
-        print("No changes have been made to " + module +
-              " since most recent release " + last_release_num)
+        usermsg.info("No changes have been made to {module}"
+                     " since most recent release {release}".format(module=module, release=last_release_num))
 
     shutil.rmtree(vcs.repo.working_tree_dir)
 
 
+def main():
+    # Catch unhandled exceptions and ensure they're logged
+    try:
+        logconfig.setup_logging(application='dls-changes-since-release.py')
+        _main()
+    except Exception as e:
+        logging.exception(e)
+        logging.getLogger("usermessages").exception("ABORT: Unhandled exception (see trace below): {}".format(e))
+        exit(1)
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/dls_ade/dls_changes_since_release.py
+++ b/dls_ade/dls_changes_since_release.py
@@ -2,6 +2,7 @@
 # This script comes from the dls_scripts python module
 
 import sys
+import json
 import shutil
 import logging
 
@@ -34,10 +35,11 @@ def make_parser():
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     pathf.check_technical_area(args.area, args.module_name)
 

--- a/dls_ade/dls_checkout_module.py
+++ b/dls_ade/dls_checkout_module.py
@@ -8,6 +8,7 @@ the given branch.
 
 import sys
 import logging
+import json
 
 from dls_ade import vcs_git
 from dls_ade.argument_parser import ArgParser
@@ -68,11 +69,12 @@ def check_technical_area(area, module):
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
 
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
+    
     if args.module_name == "":
         answer = raw_input("Would you like to checkout the whole " +
                            args.area +

--- a/dls_ade/dls_environment.py
+++ b/dls_ade/dls_environment.py
@@ -232,7 +232,7 @@ class environment(object):
             components += [0, ''] * int((6-len(components))/2)
         # pad to 12 elements
         components += [0, ''] * int((12-len(components))/2)
-        log.debug(components)
+        # log.debug(components)
         return components
 
     def sortReleases(self, paths):

--- a/dls_ade/dls_environment.py
+++ b/dls_ade/dls_environment.py
@@ -22,8 +22,7 @@ import re
 from subprocess import Popen, PIPE, STDOUT
 from ConfigParser import SafeConfigParser
 
-# logging.basicConfig(level=logging.DEBUG)
-
+log = logging.getLogger(__name__)
 
 class environment(object):
     """
@@ -233,7 +232,7 @@ class environment(object):
             components += [0, ''] * int((6-len(components))/2)
         # pad to 12 elements
         components += [0, ''] * int((12-len(components))/2)
-        logging.debug(components)
+        log.debug(components)
         return components
 
     def sortReleases(self, paths):
@@ -259,7 +258,7 @@ class environment(object):
         sorted_releases = []
         for entry in sorted(releases):
             sorted_releases.append(entry[1])
-        logging.debug(sorted_releases)
+        log.debug(sorted_releases)
 
         return sorted_releases
 

--- a/dls_ade/dls_list_branches.py
+++ b/dls_ade/dls_list_branches.py
@@ -5,6 +5,7 @@ List the branches of a module on the repository.
 """
 
 import sys
+import json
 import shutil
 import logging
 
@@ -38,10 +39,11 @@ def make_parser():
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     pathf.check_technical_area(args.area, args.module_name)
 

--- a/dls_ade/dls_list_modules.py
+++ b/dls_ade/dls_list_modules.py
@@ -4,7 +4,6 @@
 List the modules of an area or ioc domain on the repository
 """
 
-from __future__ import print_function
 import sys
 import logging
 

--- a/dls_ade/dls_list_modules.py
+++ b/dls_ade/dls_list_modules.py
@@ -5,6 +5,7 @@ List the modules of an area or ioc domain on the repository
 """
 
 import sys
+import json
 import logging
 
 from dls_ade.argument_parser import ArgParser
@@ -59,10 +60,11 @@ def get_module_list(source):
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     server = Server()
 

--- a/dls_ade/dls_list_modules.py
+++ b/dls_ade/dls_list_modules.py
@@ -6,10 +6,12 @@ List the modules of an area or ioc domain on the repository
 
 from __future__ import print_function
 import sys
+import logging
 
 from dls_ade.argument_parser import ArgParser
 from dls_ade import path_functions as pathf
 from dls_ade import Server
+from dls_ade import logconfig
 
 usage = """
 Default <area> is 'support'.
@@ -35,38 +37,58 @@ def make_parser():
     return parser
 
 
-def print_module_list(source):
+def get_module_list(source):
     """
     Prints the modules in the area of the repository specified by source.
 
     Args:
         source(str): Suffix of URL to list from
+    Returns:
+        list: List of modules (list of str)
     """
     server = Server()
     split_list = server.get_server_repo_list()
+    modules = []
     for module_path in split_list:
         if module_path.startswith(source + '/'):
             # Split module path by slashes twice and print what remains
             # after that, i.e. after 'controls/<area>/'
-            print(module_path.split('/', 2)[-1])
+            modules.append(module_path.split('/', 2)[-1])
+    return modules
 
 
-def main():
+def _main():
+    log = logging.getLogger(name="dls_ade")
+    usermsg = logging.getLogger(name="usermessages")
+    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
 
     server = Server()
-    
+
     if args.area == "ioc" and args.domain_name:
-        print("Modules in " + args.domain_name + ":\n")
+        area = args.domain_name
         source = server.dev_module_path(args.domain_name, args.area)
     else:
-        print("Modules in " + args.area + ":\n")
+        area = args.area
         source = server.dev_area_path(args.area)
+    print_msg = "Modules in {area}:\n".format(area=area)
 
-    print_module_list(source)
+    print_msg += "\n".join(get_module_list(source))
+    usermsg.info(print_msg)
+
+
+def main():
+    # Catch unhandled exceptions and ensure they're logged
+    try:
+        logconfig.setup_logging(application='dls-list-modules.py')
+        _main()
+    except Exception as e:
+        logging.exception(e)
+        logging.getLogger("usermessages").exception("ABORT: Unhandled exception (see trace below): {}".format(e))
+        exit(1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/dls_ade/dls_list_modules_test.py
+++ b/dls_ade/dls_list_modules_test.py
@@ -42,7 +42,7 @@ class PrintModuleListTest(unittest.TestCase):
     def test_server_repo_list_called(self):
         source = "test/source"
 
-        dls_list_modules.print_module_list(source)
+        dls_list_modules.get_module_list(source)
 
         self.server_mock.get_server_repo_list.assert_called_once_with()
 
@@ -53,7 +53,7 @@ class PrintModuleListTest(unittest.TestCase):
         source = "test/source"
 
         with patch.object(builtins, 'print') as mock_print:
-            dls_list_modules.print_module_list(source)
+            dls_list_modules.get_module_list(source)
 
         call_args = mock_print.call_args_list
         self.assertEqual(call_args[0][0][0], 'module')
@@ -67,6 +67,6 @@ class PrintModuleListTest(unittest.TestCase):
         source = "test/source"
 
         with patch.object(builtins, 'print') as mock_print:
-            dls_list_modules.print_module_list(source)
+            dls_list_modules.get_module_list(source)
 
         self.assertFalse(mock_print.call_count)

--- a/dls_ade/dls_list_modules_test.py
+++ b/dls_ade/dls_list_modules_test.py
@@ -1,6 +1,5 @@
 #!/bin/env dls-python
 
-from __future__ import print_function
 from sys import version_info
 if version_info.major == 2:
     import __builtin__ as builtins  # Allows for Python 2/3 compatibility, 'builtins' is namespace for inbuilt functions

--- a/dls_ade/dls_list_modules_test.py
+++ b/dls_ade/dls_list_modules_test.py
@@ -46,27 +46,22 @@ class PrintModuleListTest(unittest.TestCase):
 
         self.server_mock.get_server_repo_list.assert_called_once_with()
 
-    def test_given_valid_source_then_print_called(self):
+    def test_given_valid_source_then_list_of_modules(self):
         self.server_mock.get_server_repo_list.return_value =\
             ["test/source/module", "test/source2/module2"]
 
         source = "test/source"
 
-        with patch.object(builtins, 'print') as mock_print:
-            dls_list_modules.get_module_list(source)
+        module_list = dls_list_modules.get_module_list(source)
+        self.assertIsNotNone(module_list)
+        self.assertListEqual(module_list, ['module'])
 
-        call_args = mock_print.call_args_list
-        self.assertEqual(call_args[0][0][0], 'module')
-        # Check that module2 from source2 is not printed
-        self.assertEqual(len(call_args), 1)
-
-    def test_given_invalid_source_then_print_not_called(self):
+    def test_given_invalid_source_then_empty_list_of_modules(self):
         self.server_mock.get_server_repo_list.return_value = \
             ["test/not_source/module"]
 
         source = "test/source"
 
-        with patch.object(builtins, 'print') as mock_print:
-            dls_list_modules.get_module_list(source)
-
-        self.assertFalse(mock_print.call_count)
+        module_list = dls_list_modules.get_module_list(source)
+        self.assertIsNotNone(module_list)
+        self.assertListEqual(module_list, [])

--- a/dls_ade/dls_list_releases.py
+++ b/dls_ade/dls_list_releases.py
@@ -10,6 +10,7 @@ The git flag will list releases from the repository.
 import os
 import sys
 import shutil
+import json
 import platform
 import logging
 
@@ -87,10 +88,11 @@ def make_parser():
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     env.check_epics_version(args.epics_version)
     pathf.check_technical_area(args.area, args.module_name)

--- a/dls_ade/dls_logs_since_release.py
+++ b/dls_ade/dls_logs_since_release.py
@@ -22,8 +22,7 @@ from dls_ade.argument_parser import ArgParser
 from dls_ade.dls_environment import environment
 from dls_ade import path_functions as pathf
 from dls_ade import vcs_git, Server
-
-logging.basicConfig(level=logging.WARNING)
+from dls_ade import logconfig
 
 usage = """
 Default <area> is 'support'.
@@ -546,7 +545,10 @@ def format_message_width(message, line_len):
     return message
 
 
-def main():
+def _main():
+    log = logging.getLogger(name="dls_ade")
+    usermsg = logging.getLogger(name="usermessages")
+    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
@@ -564,7 +566,7 @@ def main():
     if server.is_server_repo(source):
         vcs = server.temp_clone(source)
         releases = vcs_git.list_module_releases(vcs.repo)
-        logging.debug(releases)
+        log.debug(releases)
     else:
         raise Exception("Module " + args.module_name +
                         " doesn't exist in " + source)
@@ -593,7 +595,7 @@ def main():
 
     # Check if there are any logs, exit if not
     if not log_info['logs']:
-        print("No logs for " + args.module_name + " between releases " +
+        usermsg.info("No logs for " + args.module_name + " between releases " +
               args.earlier_release + " and " + args.later_release)
         return 0
 
@@ -609,16 +611,29 @@ def main():
         print_bool = False
 
     release_marker = "(RELEASE: {})"
+    messages = []
     for log in formatted_logs:
         if log.endswith(release_marker.format(end)):
             print_bool = True
         if print_bool:
-            print(log)
+            messages.append(log)
         if log.endswith(release_marker.format(start)):
             break
+    usermsg.info("\n".join(messages))
 
     shutil.rmtree(vcs.repo.working_tree_dir)
 
 
+def main():
+    # Catch unhandled exceptions and ensure they're logged
+    try:
+        logconfig.setup_logging(application='dls-logs-since-release.py')
+        _main()
+    except Exception as e:
+        logging.exception(e)
+        logging.getLogger("usermessages").exception("ABORT: Unhandled exception (see trace below): {}".format(e))
+        exit(1)
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/dls_ade/dls_logs_since_release.py
+++ b/dls_ade/dls_logs_since_release.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 import os
 import sys
 import shutil
+import json
 import time
 import logging
 from operator import itemgetter
@@ -548,10 +549,11 @@ def format_message_width(message, line_len):
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     raw = set_raw_argument(args.raw)
     pathf.check_technical_area(args.area, args.module_name)

--- a/dls_ade/dls_module_contacts.py
+++ b/dls_ade/dls_module_contacts.py
@@ -13,6 +13,7 @@ will be left as it was.
 import os
 import sys
 import shutil
+import json
 import logging
 import csv
 import ldap
@@ -318,10 +319,10 @@ def edit_contact_info(repo, contact='', cc=''):
 
 
 def _main():
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
-
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     check_parsed_args_compatible(args.imp, args.modules, args.contact, args.cc,
                                  parser)

--- a/dls_ade/dls_module_contacts.py
+++ b/dls_ade/dls_module_contacts.py
@@ -20,8 +20,12 @@ import ldap
 from dls_ade.argument_parser import ArgParser
 from dls_ade import path_functions as pathf
 from dls_ade import Server
+from dls_ade import logconfig
 
-# logging.basicConfig(level=logging.DEBUG)
+# Optional but useful in a library or non-main module:
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+log = logging.getLogger(__name__)
+usermsg = logging.getLogger(name="usermessages")
 
 usage = """
 Default <area> is 'support'.
@@ -138,12 +142,12 @@ def lookup_contact_name(fed_id):
 
     # Perform search, print message so user knows where program hangs
     # The lookup can hang at l.result() if the FED-ID does not exist.
-    print("Performing search for " + fed_id + "...")
+    log.debug("Performing search for {}".format(fed_id))
     l.simple_bind_s()
     ldap_result_id = l.search(basedn, search_scope, search_filter,
                               search_attribute)
     ldap_output = l.result(ldap_result_id, 0)
-    logging.debug(ldap_output)
+    log.debug(ldap_output)
     # ldap_output has the form:
     # (100, [('CN=<FED-ID>,OU=DLS,DC=fed,DC=cclrc,DC=ac,DC=uk',
     # {'givenName': ['<FirstName>'], 'sn': ['<Surname>']})])
@@ -152,7 +156,7 @@ def lookup_contact_name(fed_id):
         # If the FED-ID does not exist, ldap_output will look like:
         # (115, [(None,
         # ['ldap://res02.fed.cclrc.ac.uk/DC=res02,DC=fed,DC=cclrc,DC=ac,DC=uk'])])
-        raise Exception(fed_id + " is not an existing contact")
+        raise Exception("\"{}\" is not an existing contact".format(fed_id))
 
     # Extract contact name from output
     name_info_dict = ldap_output[1][0][1]
@@ -165,7 +169,7 @@ def lookup_contact_name(fed_id):
 
 def output_csv_format(contact, cc_contact, module):
     """
-    Print out contact info in CSV format.
+    Format contact info string in CSV format.
 
     Args:
         contact(str): Contact FED-ID
@@ -213,7 +217,7 @@ def import_from_csv(modules, area, imp):
     csv_file = []
     for row in reader:
         csv_file.append(row)
-    logging.debug(csv_file)
+    log.debug(csv_file)
 
     if not csv_file:
         raise Exception("CSV file is empty")
@@ -265,8 +269,8 @@ def edit_contact_info(repo, contact='', cc=''):
     current_cc = repo.git.check_attr("module-cc", ".").split(' ')[-1]
 
     if contact in [current_contact, ''] and cc in [current_cc, '']:
-        print("Leaving contacts unchanged")
-        return 0
+        usermsg.info("Leaving contacts unchanged ({contact}, {cc})".format(contact=current_contact, cc=current_cc))
+        return
 
     # Check that FED-IDs exist,
     # if they don't lookup...() will (possibly) hang and raise an exception
@@ -288,19 +292,22 @@ def edit_contact_info(repo, contact='', cc=''):
             repo.working_tree_dir, '.gitattributes'), 'w') as git_attr_file:
 
         commit_message = ''
+        user_msg = "{}: ".format(module)
         if contact:
-            print("{0}: Setting contact to {1}".format(module, contact))
+            user_msg += "Setting contact to {}".format(contact)
             commit_message += "Set contact to {}. ".format(contact)
             git_attr_file.write("* module-contact={}\n".format(contact))
         if cc:
-            print("{0}: Setting cc to {1}".format(module, cc))
+            user_msg += " Setting cc to {}".format(cc)
             commit_message += "Set cc to {}.".format(cc)
             git_attr_file.write("* module-cc={}\n".format(cc))
+        usermsg.info(user_msg)
 
     return commit_message
 
 
-def main():
+def _main():
+    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
@@ -330,7 +337,7 @@ def main():
             try:
                 vcs = server.temp_clone(source)
             except ValueError:
-                print("Module {} does not exist in {} [{}]".format(
+                log.error("Module {} does not exist in {} [{}]".format(
                     module, args.area, source))
                 continue
 
@@ -344,18 +351,17 @@ def main():
                 print_out.append(output_csv_format(
                     contact, cc_contact, module))
             else:
-                print_out.append(module +
-                                 " Contact: " + contact +
-                                 " (CC: " + cc_contact + ")")
+                print_out.append("{module} Contact: {contact}, CC: {cc}"
+                                 .format(cc=cc_contact, contact=contact, module=module))
 
             shutil.rmtree(vcs.repo.working_tree_dir)
 
+        module_contacts_str = ""
         if args.csv:
-            print("Module,Contact,Contact Name,CC,CC Name")
-        for entry in print_out:
-            print(entry)
-
-        return 0
+            module_contacts_str += "Module,Contact,Contact Name,CC,CC Name\n"
+        module_contacts_str += "\n".join(print_out)
+        usermsg.info(module_contacts_str)  # print the list of module owners
+        return
 
     # If we get to this point, we are assigning contacts
 
@@ -369,26 +375,35 @@ def main():
 
     # Checkout modules and change contacts
     for module, contact, cc in contacts:
-
-        print("Cloning " + module + " from " + args.area + " area...")
+        log.debug("Cloning {module} from {area}".format(module=module, area=args.area))
         source = server.dev_module_path(module, args.area)
         vcs = server.temp_clone(source)
         repo = vcs.repo
 
         edit_summary = edit_contact_info(repo, contact, cc,)
 
-        if edit_summary != 0:
+        if edit_summary is not None:
             index = repo.index
             index.add(['.gitattributes'])
             index.commit(edit_summary)
 
             origin = repo.remotes.origin
+            log.debug("Pushing module contact/cc attributes to remote on \'{}\'".format(repo.active_branch))
             origin.push(repo.active_branch)
 
         shutil.rmtree(repo.working_tree_dir)
 
 
+def main():
+    # Catch unhandled exceptions and ensure they're logged
+    try:
+        logconfig.setup_logging(application='dls-module-contacts.py')
+        _main()
+    except Exception as e:
+        logging.exception(e)
+        logging.getLogger("usermessages").exception("ABORT: Unhandled exception (see trace below): {}".format(e))
+        exit(1)
+
+
 if __name__ == "__main__":
-    from pkg_resources import require
-    require("python_ldap>=2.3.12")
-    sys.exit(main())
+    main()

--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -17,14 +17,16 @@ the server
 import sys
 import re
 import logging
+import logconfig
 
 from dls_ade import Server
 from dls_ade import dlsbuild
 from dls_ade.argument_parser import ArgParser
 from dls_ade.dls_environment import environment
-import dls_ade.path_functions as pathf
 
-# logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(name="dls_ade")
+logconfig.setup_logging()
+usermsg = logging.getLogger(name="usermessages")
 
 usage = """
 Default <area> is 'support'.
@@ -224,7 +226,7 @@ def next_version_number(releases, module=None):
         last_release = get_last_release(releases)
         version = increment_version_number(last_release)
         if module:
-            print("Last release for {module} was {last_release}".format(
+            usermsg.info("Last release for {module} was {last_release}".format(
                 module=module, last_release=last_release))
     return version
 
@@ -388,7 +390,7 @@ def perform_test_build(build_object, local_build, vcs):
 
 
 def main():
-
+    usermsg = logging.getLogger(name="usermessages")
     parser = make_parser()
     args = parser.parse_args()
 
@@ -415,7 +417,7 @@ def main():
 
     vcs.set_version(version)
 
-    print(construct_info_message(module, args.branch, args.area, version,
+    usermsg.info(construct_info_message(module, args.branch, args.area, version,
                                  build))
 
     if args.area in ["ioc", "support"]:
@@ -429,7 +431,7 @@ def main():
     if not args.skip_test:
         test_build_message, test_build_fail = perform_test_build(
             build, args.local_build, vcs)
-        print(test_build_message)
+        usermsg.info(test_build_message)
         if test_build_fail:
             sys.exit(1)
 
@@ -440,4 +442,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    try:
+        log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
+        main()
+    except Exception as e:
+        log.exception(e)
+        exit(1)

--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -387,8 +387,8 @@ def perform_test_build(build_object, local_build, vcs):
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-
     log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
+
     parser = make_parser()
     args = parser.parse_args()
 

--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -24,8 +24,8 @@ from dls_ade import dlsbuild
 from dls_ade.argument_parser import ArgParser
 from dls_ade.dls_environment import environment
 
-log = logging.getLogger(name="dls_ade")
 logconfig.setup_logging()
+log = logging.getLogger(name="dls_ade")
 usermsg = logging.getLogger(name="usermessages")
 
 usage = """

--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -15,6 +15,7 @@ the server
 """
 
 import sys
+import json
 import re
 import logging
 import logconfig
@@ -387,10 +388,11 @@ def perform_test_build(build_object, local_build, vcs):
 def _main():
     log = logging.getLogger(name="dls_ade")
     usermsg = logging.getLogger(name="usermessages")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     check_parsed_arguments_valid(args, parser)
     module = args.module_name

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -1,14 +1,11 @@
 #!/bin/env dls-python
 
 import unittest
-import logging
 from dls_ade import dls_release
 
 from mock import patch, ANY, MagicMock
 from argparse import _StoreAction
 from argparse import _StoreTrueAction
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 def set_up_mock(self, path):

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -475,7 +475,7 @@ class TestConstructInfoMessage(unittest.TestCase):
         options = FakeOptions()
         build = dls_release.create_build_object(options)
 
-        expected_message = 'Releasing {module} {version} from trunk, '.format(module=module, version=version)
+        expected_message = '{module} {version} from tag: {version}, '.format(module=module, version=version)
         expected_message += 'using {} build server'.format(build.get_server())
         expected_message += ' and epics {}'.format(build.epics())
 
@@ -495,7 +495,7 @@ class TestConstructInfoMessage(unittest.TestCase):
         build = dls_release.create_build_object(options)
 
         expected_message = \
-            'Releasing {module} {version} from branch {branch}, '.format(module=module, version=version, branch=branch)
+            '{module} {version} from branch {branch}, '.format(module=module, version=version, branch=branch)
         expected_message += 'using {} build server'.format(build.get_server())
         expected_message += ' and epics {}'.format(build.epics())
 
@@ -514,7 +514,7 @@ class TestConstructInfoMessage(unittest.TestCase):
         options = FakeOptions(area='ioc')
         build = dls_release.create_build_object(options)
 
-        expected_message = 'Releasing {module} {version} from trunk, '.format(module=module, version=version)
+        expected_message = '{module} {version} from tag: {version}, '.format(module=module, version=version)
         expected_message += 'using {} build server'.format(build.get_server())
         expected_message += ' and epics {}'.format(build.epics())
 

--- a/dls_ade/dls_start_new_module.py
+++ b/dls_ade/dls_start_new_module.py
@@ -11,6 +11,7 @@ Can currently create modules in the following areas:
 """
 
 import sys
+import json
 import logging
 from dls_ade.argument_parser import ArgParser
 from dls_ade.get_module_creator import get_module_creator
@@ -67,11 +68,12 @@ def make_parser():
 
 def _main():
     log = logging.getLogger(name="dls_ade")
-    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
     usermsg = logging.getLogger("usermessages")
 
     parser = make_parser()
     args = parser.parse_args()
+
+    log.info(json.dumps({'CLI': sys.argv, 'options_args': vars(args)}))
 
     module_name = args.module_name
     area = args.area

--- a/dls_ade/dls_start_new_module.py
+++ b/dls_ade/dls_start_new_module.py
@@ -10,11 +10,11 @@ Can currently create modules in the following areas:
 - ioc (including BL gui)
 """
 
-from __future__ import print_function
-
 import sys
+import logging
 from dls_ade.argument_parser import ArgParser
 from dls_ade.get_module_creator import get_module_creator
+from dls_ade import logconfig
 
 usage = ("Default <area> is 'support'."
          "\nStart a new diamond module of a particular type."
@@ -65,7 +65,10 @@ def make_parser():
     return parser
 
 
-def main():
+def _main():
+    log = logging.getLogger(name="dls_ade")
+    log.info("application: %s: arguments: %s", sys.argv[0], sys.argv)
+    usermsg = logging.getLogger("usermessages")
 
     parser = make_parser()
     args = parser.parse_args()
@@ -87,7 +90,20 @@ def main():
     if export_to_server:
         module_creator.push_repo_to_remote()
 
-    module_creator.print_message()
+    msg = module_creator.get_print_message()
+    usermsg.info(msg)
+
+
+def main():
+    # Catch unhandled exceptions and ensure they're logged
+    try:
+        logconfig.setup_logging(application='dls-release.py')
+        return _main()
+    except Exception as e:
+        logging.exception(e)
+        logging.getLogger("usermessages").exception("ABORT: Unhandled exception (see trace below): {}".format(e))
+        exit(1)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -336,18 +336,3 @@ class ArchiveBuild(Builder):
     def script_file(self):
         return os.path.join(build_scripts, self.os, "archive.sh")
 
-
-if __name__ == "__main__":
-    from pkg_resources import require
-    require("python_ldap>=2.3.12")
-
-    # test
-    bld = WindowsBuild("64")
-    bld.set_area("support")
-    bld.set_epics("R3.14.12.3")
-    print("build_script is:\n" + bld.build_script({"test": root_dir + "/test"}))
-
-    bld = ArchiveBuild(True)
-    bld.set_area("archive")
-    bld.set_epics("R3.14.12.3")
-    print("build_script is:\n"+bld.build_script({"test": root_dir+"/test"}))

--- a/dls_ade/exceptions.py
+++ b/dls_ade/exceptions.py
@@ -47,3 +47,8 @@ class VerificationError(ModuleCreatorError):
 
     """
     pass
+
+
+class FedIdError(Exception):
+    """Exception class for errors related to fed-id"""
+    pass

--- a/dls_ade/get_module_creator.py
+++ b/dls_ade/get_module_creator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from dls_ade import path_functions as pathf
 import logging
 from dls_ade import Server

--- a/dls_ade/get_module_creator.py
+++ b/dls_ade/get_module_creator.py
@@ -5,8 +5,6 @@ from dls_ade import module_template as mt
 from dls_ade import module_creator as mc
 from dls_ade.exceptions import ParsingError
 
-# logging.basicConfig(level=logging.DEBUG)
-
 
 def get_module_creator(module_name, area="support", fullname=False):
     """Returns a :class:`ModuleCreator` subclass object.

--- a/dls_ade/gitoliteserver.py
+++ b/dls_ade/gitoliteserver.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import subprocess
+import logging
 
 from dls_ade.gitserver import GitServer
 from dls_ade import path_functions as pathf
@@ -9,6 +10,10 @@ from dls_ade.vcs_git import git
 
 GIT_ROOT = "dascgitolite@dasc-git.diamond.ac.uk"
 GIT_SSH_ROOT = "ssh://" + GIT_ROOT + "/"
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+log = logging.getLogger(__name__)
+usermsg = logging.getLogger("usermessages")
 
 
 class GitoliteServer(GitServer):
@@ -41,7 +46,9 @@ class GitoliteServer(GitServer):
         list_cmd = "ssh " + GIT_ROOT + " expand controls"
         if area:
             list_cmd += "/" + area
+        log.debug("area: \"{area}\" ssh: \"{sshcmd}\"".format(area=area, sshcmd=list_cmd))
         list_cmd_output = subprocess.check_output(list_cmd.split())
+        log.debug("\"gitolite response\": \"{}\"".format(list_cmd_output))
         # list_cmd_output is a heading followed by a module list in the form:
         # R   W 	(alan.greer)	controls/support/ADAndor
         # R   W 	(ronaldo.mercado)	controls/support/ethercat
@@ -72,7 +79,7 @@ class GitoliteServer(GitServer):
 
         git_dest = os.path.join(self.url, dest)
 
-        print("Creating remote...")
+        usermsg.info("Creating remote on gitolite: {}".format(git_dest))
         temp_dir = tempfile.mkdtemp()
 
         try:

--- a/dls_ade/gitserver.py
+++ b/dls_ade/gitserver.py
@@ -1,8 +1,12 @@
 import os
 import tempfile
+import logging
 
 from dls_ade.vcs_git import Git, git
 from dls_ade import path_functions as pathf
+
+log = logging.getLogger(__name__)
+usermsg = logging.getLogger("usermessages")
 
 
 class GitServer(object):
@@ -138,16 +142,16 @@ class GitServer(object):
 
                 # Remove controls/<area>/ from front of save path
                 module = path.split('/', 2)[-1]
-                print("Module: " + module)
+                log.debug("Module: {}".format(module))
 
                 if module not in os.listdir("./"):
-                    print("Cloning: " + path + "...")
+                    usermsg.info("Cloning: {}".format(path))
                     git.Repo.clone_from(
                         os.path.join(self.clone_url,
                                      self.get_clone_path(path)),
                         os.path.join("./", module))
                 else:
-                    print(module + " already exists in current directory")
+                    usermsg.info(module + " already exists in current directory")
 
     def create_remote_repo(self, dest):
         """

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -6,6 +6,7 @@ the project or site requirements.
 """
 
 import os
+import os.path
 import json
 import logging.config
 import getpass
@@ -20,7 +21,7 @@ default_config = {
             "format": "%(message)s"
         },
         "extended": {
-            "format": "%(asctime)s - %(filename)20s:%(lineno)d - %(name)20s - %(levelname)6s - %(message)s"
+            "format": "%(asctime)s - %(filename)24s:%(lineno)d - %(name)24s - %(levelname)6s - %(message)s"
         },
         "json": {
             "format": "name: %(name)s, level: %(levelname)s, time: %(asctime)s, message: %(message)s"
@@ -40,7 +41,7 @@ default_config = {
             #  "class": "logging.handlers.FileHandler",
             "level": "DEBUG",
             "formatter": "extended",
-            "filename": "debug.log",
+            "filename": os.path.join(os.getenv('HOME', '~'), ".dls_ade_debug.log"),
             "maxBytes": 1048576,
             "backupCount": 20,
             "encoding": "utf8",

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -57,7 +57,8 @@ default_config = {
             #  The following custom fields will be disabled if setting this False
             "include_extra_fields": True,
             "username": getpass.getuser(),
-            "pid": os.getpid()
+            "pid": os.getpid(),
+            "package": __package__
         }
     },
 
@@ -97,7 +98,8 @@ class ThreadContextFilter(logging.Filter):
 def setup_logging(
     default_log_config=None,
     default_level=logging.INFO,
-    env_key='ADE_LOG_CFG'
+    env_key='ADE_LOG_CFG',
+    application=None
 ):
     """Setup logging configuration
     
@@ -137,6 +139,11 @@ def setup_logging(
             dict_config = file_config
 
     if dict_config is not None:
+        if application is not None:
+            try:
+                default_config['handlers']['graylog_gelf'].update({'application': str(application)})
+            except KeyError:
+                pass
         logging.config.dictConfig(dict_config)
     else:
         logging.basicConfig(level=default_level)

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -20,7 +20,7 @@ default_config = {
             "format": "%(message)s"
         },
         "extended": {
-            "format": "%(asctime)s - %(name)20s - %(levelname)6s - %(message)s"
+            "format": "%(asctime)s - %(filename)20s:%(lineno)d - %(name)20s - %(levelname)6s - %(message)s"
         },
         "json": {
             "format": "name: %(name)s, level: %(levelname)s, time: %(asctime)s, message: %(message)s"

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -45,15 +45,16 @@ default_config = {
             "maxBytes": 1048576,
             "backupCount": 20,
             "encoding": "utf8",
-            "delay" : True
+            "delay": True
         },
 
         "graylog_gelf": {
-            "class": "pygelf.GelfUdpHandler",
+            "class": "pygelf.GelfTcpHandler",
             "level": "INFO",
             # Obviously a DLS-specific configuration: the graylog server address and port
-            "host": "cs04r-sc-serv-14.diamond.ac.uk",
-            "port": 12202,
+            # Graylog2 cluster. Input: "Load-Balanced GELF TCP"
+            "host": "graylog2",
+            "port": 12201,
             "debug": True,
             #  The following custom fields will be disabled if setting this False
             "include_extra_fields": True,

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -1,0 +1,143 @@
+""" logconfig
+
+This is essentially a template which can be copied into a python project and
+used to easily achieve a good practice of logging. Modify the local copy as per 
+the project or site requirements.
+"""
+
+import os
+import json
+import logging.config
+import getpass
+import threading
+
+
+default_config = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {
+            "format": "%(message)s"
+        },
+        "extended": {
+            "format": "%(asctime)s - %(name)20s - %(levelname)6s - %(message)s"
+        },
+        "json": {
+            "format": "name: %(name)s, level: %(levelname)s, time: %(asctime)s, message: %(message)s"
+            }
+    },
+
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "simple",
+            "stream": "ext://sys.stdout"
+        },
+
+        "local_file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            #  "class": "logging.handlers.FileHandler",
+            "level": "DEBUG",
+            "formatter": "extended",
+            "filename": "debug.log",
+            "maxBytes": 1048576,
+            "backupCount": 20,
+            "encoding": "utf8",
+            "delay" : True
+        },
+
+        "graylog_gelf": {
+            "class": "pygelf.GelfUdpHandler",
+            "level": "INFO",
+            # Obviously a DLS-specific configuration: the graylog server address and port
+            "host": "cs04r-sc-serv-14.diamond.ac.uk",
+            "port": 12202,
+            "debug": True,
+            #  The following custom fields will be disabled if setting this False
+            "include_extra_fields": True,
+            "username": getpass.getuser(),
+            "pid": os.getpid()
+        }
+    },
+
+    "loggers": {
+        # Fine-grained logging configuration for individual modules or classes
+        # Use this to set different log levels without changing 'real' code.
+        "dls_ade": {
+            "level": "DEBUG",
+            "propagate": True
+        },
+        "usermessages": {
+            "level": "INFO",
+            "propagate": True,
+            "handlers": ["console"]
+        }
+    },
+
+    "root": {
+        # Set the level here to be the default minimum level of log record to be produced
+        # If you set a handler to level DEBUG you will need to set either this level, or
+        # the level of one of the loggers above to DEBUG or you won't see any DEBUG messages
+        "level": "INFO",
+        "handlers": ["local_file_handler", "graylog_gelf"],
+        #"handlers": ["console"],
+    }
+}
+
+
+class ThreadContextFilter(logging.Filter):
+    """A logging context filter to add thread name and ID."""
+    def filter(self, record):
+        record.thread_id = str(threading.current_thread().ident)
+        record.thread_name = str(threading.current_thread().name)
+        return True
+
+
+def setup_logging(
+    default_log_config=None,
+    default_level=logging.INFO,
+    env_key='ADE_LOG_CFG'
+):
+    """Setup logging configuration
+    
+    Call this only once from the application main() function or __main__ module!
+    
+    This will configure the python logging module based on a logging configuration
+    in the following order of priority:
+       
+       1. Log configuration file found in the environment variable specified in the `env_key` argument.
+       2. Log configuration file found in the `default_log_config` argument.
+       3. Default log configuration found in the `logconfig.default_config` dict.
+       4. If all of the above fails: basicConfig is called with the `default_level` argument.
+    
+    Args:
+        default_log_config (Optional[str]): Path to log configuration file.
+        env_key (Optional[str]): Environment variable that can optionally contain
+            a path to a configuration file.
+        default_level (int): logging level to set as default. Ignored if a log
+            configuration is found elsewhere.
+ 
+    Returns: None
+    """
+    dict_config = None
+    logconfig_filename = default_log_config
+    env_var_value = os.getenv(env_key, None)
+
+    if env_var_value is not None:
+        logconfig_filename = env_var_value
+
+    if default_config is not None:
+        dict_config = default_config
+
+    if logconfig_filename is not None and os.path.exists(logconfig_filename):
+        with open(logconfig_filename, 'rt') as f:
+            file_config = json.load(f)
+        if file_config is not None:
+            dict_config = file_config
+
+    if dict_config is not None:
+        logging.config.dictConfig(dict_config)
+    else:
+        logging.basicConfig(level=default_level)
+

--- a/dls_ade/module_creator.py
+++ b/dls_ade/module_creator.py
@@ -1,15 +1,11 @@
-from __future__ import print_function
 import os
+import logging
 from getpass import getuser
 from dls_ade import path_functions as pathf
 import shutil
-import logging
-from dls_ade.vcs_git import git
 from dls_ade import vcs_git, Server
 from dls_ade.exceptions import (RemoteRepoError, VerificationError,
                                 ArgumentError)
-
-# logging.basicConfig(level=logging.DEBUG)
 
 
 class ModuleCreator(object):
@@ -50,6 +46,7 @@ class ModuleCreator(object):
                 Must be a non-abstract subclass of ModuleTemplate.
             kwargs: Additional arguments for module creation.
         """
+        self._usermsg = logging.getLogger("usermessages")
 
         self._area = area
         self._cwd = os.getcwd()
@@ -216,7 +213,7 @@ class ModuleCreator(object):
 
         self._can_create_local_module = False
 
-        print("Making clean directory structure for " + self._module_path)
+        self._usermsg.info("Making clean directory structure for {}".format(self._module_path))
 
         os.makedirs(self.abs_module_path)
 
@@ -232,9 +229,9 @@ class ModuleCreator(object):
         repo = vcs_git.init_repo(self.abs_module_path)
         vcs_git.stage_all_files_and_commit(repo)
 
-    def print_message(self):
+    def get_print_message(self):
         """Prints a message to detail the user's next steps."""
-        self._module_template.print_message()
+        return self._module_template.get_print_message()
 
     def push_repo_to_remote(self):
         """Pushes the local repo to the remote server.
@@ -431,7 +428,7 @@ class ModuleCreatorAddAppToModule(ModuleCreatorWithApps):
 
         self._can_create_local_module = False
 
-        print("Cloning module to " + self._module_path)
+        self._usermsg.info("Cloning module to {}".format(self._module_path))
 
         vcs = self.server.clone(self._server_repo_path, self.abs_module_path)
 

--- a/dls_ade/module_creator_test.py
+++ b/dls_ade/module_creator_test.py
@@ -329,7 +329,7 @@ class ModuleCreatorPrintMessageTest(unittest.TestCase):
 
     def test_given_function_called_then_module_template_print_message_called(self):
 
-        self.nmc_obj.print_message()
+        self.nmc_obj.get_print_message()
 
         self.mock_module_template.print_message_assert_called_once_with()
 

--- a/dls_ade/module_template_test.py
+++ b/dls_ade/module_template_test.py
@@ -396,13 +396,12 @@ class ModuleTemplatePrintMessageTest(unittest.TestCase):
     def test_given_print_message_called_then_not_implemented_error_raised(self):
 
         with self.assertRaises(NotImplementedError):
-            self.mt_obj.print_message()
+            self.mt_obj.get_print_message()
 
 
 class ModuleTemplateToolsPrintMessageTest(unittest.TestCase):
 
-    @patch('dls_ade.module_template.print', create=True)
-    def test_given_print_message_called_then_message_printed(self, mock_print):
+    def test_given_print_message_called_then_message_printed(self):
 
         mt_obj = mt.ModuleTemplateTools({'module_name': "test_module_name",
                                          'module_path': "test_module_path",
@@ -412,15 +411,13 @@ class ModuleTemplateToolsPrintMessageTest(unittest.TestCase):
                         "\ndirectory and edit test_module_path/build script "
                         "appropriately.")
 
-        mt_obj.print_message()
-
-        mock_print.assert_called_once_with(comp_message)
+        msg = mt_obj.get_print_message()
+        self.assertEqual(msg, comp_message)
 
 
 class ModuleTemplatePythonPrintMessageTest(unittest.TestCase):
 
-    @patch('dls_ade.module_template.print', create=True)
-    def test_given_print_message_called_then_message_printed(self, mock_print):
+    def test_given_print_message_called_then_message_printed(self):
 
         mt_obj = mt.ModuleTemplatePython({'module_name': "test_module_name",
                                           'module_path': "test_module_path",
@@ -435,15 +432,13 @@ class ModuleTemplatePythonPrintMessageTest(unittest.TestCase):
                         "\ndirectory and edit {setup_path} appropriately.")
         comp_message = comp_message.format(**message_dict)
 
-        mt_obj.print_message()
-
-        mock_print.assert_called_once_with(comp_message)
+        msg = mt_obj.get_print_message()
+        self.assertEqual(msg, comp_message)
 
 
 class ModuleTemplateWithAppsPrintMessageTest(unittest.TestCase):
 
-    @patch('dls_ade.module_template.print', create=True)
-    def test_given_print_message_called_then_message_printed(self, mock_print):
+    def test_given_print_message_called_then_message_printed(self):
 
         mt_obj = mt.ModuleTemplateWithApps({'module_name': "test_module_name",
                                                   'module_path': "test_module_path",
@@ -461,9 +456,8 @@ class ModuleTemplateWithAppsPrintMessageTest(unittest.TestCase):
                         "{srcMakefile:s}\nand {DbMakefile:s} if appropriate.")
         comp_message = comp_message.format(**message_dict)
 
-        mt_obj.print_message()
-
-        mock_print.assert_called_once_with(comp_message)
+        msg = mt_obj.get_print_message()
+        self.assertEqual(msg, comp_message)
 
 
 class ModuleTemplateSupportCreateCustomFilesTest(unittest.TestCase):
@@ -601,8 +595,7 @@ class ModuleTemplateIOCBLCreateCustomFilesTest(unittest.TestCase):
 
 class ModuleTemplateIOCBLPrintMessageTest(unittest.TestCase):
 
-    @patch('dls_ade.module_template.print', create=True)
-    def test_given_print_message_called_then_message_printed(self, mock_print):
+    def test_given_print_message_called_then_message_printed(self):
 
         mt_obj = mt.ModuleTemplateIOCBL({'module_name': "test_module_name",
                                          'module_path': "test_module_path",
@@ -623,6 +616,5 @@ class ModuleTemplateIOCBLPrintMessageTest(unittest.TestCase):
 
         comp_message = comp_message.format(**message_dict)
 
-        mt_obj.print_message()
-
-        mock_print.assert_called_once_with(comp_message)
+        msg = mt_obj.get_print_message()
+        self.assertEqual(msg, comp_message)

--- a/dls_ade/module_template_test.py
+++ b/dls_ade/module_template_test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import unittest
 import os

--- a/dls_ade/vcs_git.py
+++ b/dls_ade/vcs_git.py
@@ -1,9 +1,14 @@
 import os
 
 import git
+import logging
 
 from dls_ade.vcs import BaseVCS
 from dls_ade.exceptions import VCSGitError
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+log = logging.getLogger(__name__)
+usermsg = logging.getLogger("usermessages")
 
 
 def is_in_local_repo(path="./"):
@@ -79,9 +84,9 @@ def init_repo(path="./"):
     if is_local_repo_root(path):
         return git.Repo(path)
 
-    print("Initialising repo...")
+    usermsg.info("Initialising repo in {}".format(path))
     repo = git.Repo.init(path)
-    print("Repository created.")
+    usermsg.info("Repository created.")
 
     return repo
 
@@ -98,10 +103,10 @@ def stage_all_files_and_commit(repo, message="Initial commit."):
             repository.
     """
 
-    print("Staging files...")
+    usermsg.info("Staging files...")
     repo.git.add('--all')
 
-    print("Committing files to repo...")
+    usermsg.info("Committing files to repo... commit msg: \"{}\"".format(message))
     index = repo.index
     # If there are no changes to commit, then GitCommandError will be raised.
     # There is no reason to raise an exception for this.
@@ -187,7 +192,7 @@ def checkout_remote_branch(branch, repo):
     """
 
     if branch in list_remote_branches(repo):
-        print("Checking out " + branch + " branch.")
+        usermsg.info("Checking out branch: {}".format(branch))
         origin = repo.remotes.origin
         remote = origin.refs[branch]
         remote.checkout(b=branch)
@@ -411,7 +416,7 @@ class Git(BaseVCS):
                            "currently exist")
             raise VCSGitError(err_message.format(s_repo_path=server_repo_path))
 
-        print("Pushing repo to destination...")
+        usermsg.info("Pushing repo to destination...")
         remote.push(branch_name)
 
     def add_new_remote_and_push(self, dest, remote_name="origin",
@@ -455,10 +460,10 @@ class Git(BaseVCS):
             raise VCSGitError(err_message.format(remote=remote_name))
 
         self.parent.create_remote_repo(dest)
-        print("Adding remote to repo...")
-        remote = repo.create_remote(remote_name, os.path.join(
-            self.parent.url, dest))
-        print("Pushing repo to destination...")
+        remote_url = os.path.join(self.parent.url, dest)
+        usermsg.info("Adding remote to repo. {name}: {url}".format(name=dest, url=remote_url))
+        remote = repo.create_remote(remote_name, remote_url)
+        usermsg.info("Pushing repo to destination...")
         remote.push(branch_name)
 
     def push_all_branches_and_tags(self, server_repo_path, remote_name):

--- a/dls_ade/vcs_git.py
+++ b/dls_ade/vcs_git.py
@@ -1,7 +1,5 @@
 import os
 
-from pkg_resources import require
-require('GitPython')
 import git
 
 from dls_ade.vcs import BaseVCS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 GitPython==2.1.8
 python-ldap==2.4.41
 six==1.10.0
-pygelf==0.2.11
+pygelf==0.3.1
 
 # For docs
 sphinx>=1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 GitPython==2.1.8
 python-ldap==2.4.41
 six==1.10.0
+pygelf==0.2.11
 
 # For docs
 sphinx>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     license='APACHE',
-    install_requires=['GitPython==2.1.8', 'python-ldap==2.4.41', 'six==1.10.0'],
+    install_requires=['GitPython==2.1.8', 'python-ldap==2.4.41', 'six==1.10.0', 'pygelf==0.3.1'],
     packages=["dls_ade"],
     package_data={"dls_ade": additional_files},
     # define console_scripts


### PR DESCRIPTION
Removing use of print() in scripts and adding a proper python logging configuration. 

* User messages to be printed to stdout are handled by a logger named "usermessages" which has an appropriate console handler and blank formatting. 
* Module-level loggers are named by the module name, by getting a logger like this: `log = logging.getLogger(__name__)`
* main() functions have all been wrapped to catch and log un-handled exceptions.
* Each dls-* script now start by issuing a log message with all of the CLI options and args.
* All info messages (and beyond) are logged to graylog and currently debug and beyond is output to a local log file in `~/.dls_ade_debug.log`

The logging configuration is based on our own recommendations: https://confluence.diamond.ac.uk/x/gRB_Aw and https://github.com/dls-controls/python-logging-configuration 