### PR TITLE
Build server logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ A local debug log is also written to the users home dir: `$HOME/.dls_ade_debug.l
 To review logs produced by the scripts for a given user, visit 
 https://graylog2.diamond.ac.uk 
 and search `package:dls_ade AND username:fedid` (replacing `fedid` for the users FedID)
+
+For releases on the build server, it is possible to view both logs from the client side
+script (i.e. dls-release.py) as well as the build server process. See all logs for a
+given module that you have released with the search:
+`username:FEDID module:MODULE` replacing FEDID and MODULE.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ given module that you have released with the search:
 
 The environment variables ADE_GELFLOG_SERVER and ADE_GELFLOG_SERVER_PORT can be used to
 override the log destination of the ADE scripts for testing/development purposes.
+
+The environment variables ADE_SYSLOG_SERVER and ADE_SYSLOG_SERVER_PORT can be used to
+override the log destination of the Controls Build Server scripts for testing/development purposes.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ For releases on the build server, it is possible to view both logs from the clie
 script (i.e. dls-release.py) as well as the build server process. See all logs for a
 given module that you have released with the search:
 `username:FEDID module:MODULE` replacing FEDID and MODULE.
+
+The environment variables ADE_GELFLOG_SERVER and ADE_GELFLOG_SERVER_PORT can be used to
+override the log destination of the ADE scripts for testing/development purposes.

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -192,8 +192,9 @@ class Builder:
         for name in params.keys():
             script += format % ("_" + name, params[name]+"\n")
 
-        for line in file(self.script_file()):
-            script += line
+        with open(self.script_file(), 'r') as f:
+            # skip the first line with the bin/bash
+            script += "".join(f.readlines()[1:])
 
         return script
 

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -226,7 +226,10 @@ class Builder:
             "version"               : vcs.version,
             "area"                  : self.area,
             "force"                 : "true" if self.force else "false",
-            "build_name"            : build_name}
+            "build_name"            : build_name,
+            "dls_syslog_server"     : os.getenv("ADE_SYSLOG_SERVER", "graylog2.diamond.ac.uk"),
+            "dls_syslog_server_port": os.getenv("ADE_SYSLOG_SERVER_PORT", "12209")
+        }
 
     def local_test_possible(self):
         """Returns True if a local test build is possible"""

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -185,12 +185,24 @@ class Builder:
         """Returns the files system path to the raw build script file"""
         return os.path.join(build_scripts, self.os, self.area+self.exten)
 
+    def script_utils_template_file(self):
+        """Returns the file system path to the script utility template for the relevant OS"""
+        return os.path.join(build_scripts, self.os, "utils_template" + self.exten)
+
     def _script(self, params, header, format):
         """Returns the build script with headers and variables defined"""
         script = header+"\n\n"
 
         for name in params.keys():
             script += format % ("_" + name, params[name]+"\n")
+
+        try:
+            with open(self.script_utils_template_file(), 'r') as f:
+                # skip the first line with the bin/bash
+                script += "".join(f.readlines()[1:])
+        except IOError:
+            # No all platforms have a utils_template and thats ok...
+            log.debug("No utils_template script found in: {}".format(self.script_utils_template_file()))
 
         with open(self.script_file(), 'r') as f:
             # skip the first line with the bin/bash

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -205,6 +205,7 @@ class Builder:
     def build_params(self, build_dir, vcs, build_name):
         return {
             "email"                 : self.email,
+            "user"                  : self.user,
             "epics"                 : self.dls_env.epicsVer(),
             "build_dir"             : build_dir,
             "%s_dir" % vcs.vcs_type : vcs.source_repo,

--- a/dls_ade/dlsbuild_scripts/Linux/epics.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/epics.sh
@@ -9,6 +9,7 @@
 # dls-release mechanism. These variables are:
 #
 #   _email     : The email address of the user who initiated the build
+#   _user      : The username (fed ID) of the user who initiated the build
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.
@@ -19,14 +20,6 @@
 #   _force     : Force the build (i.e. rebuild even if already exists)
 #   _build_name: The base name to use for log files etc.
 #
-
-
-ReportFailure()
-{
-    { [ -f "$1" ] && cat $1 || echo $*; } |
-    mail -s "Build Errors: $_area $_module $_version"         $_email
-    exit 2
-}
 
 # Set up environment
 export PATH

--- a/dls_ade/dlsbuild_scripts/Linux/etc.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/etc.sh
@@ -9,6 +9,7 @@
 # dls-release mechanism. These variables are:
 #
 #   _email     : The email address of the user who initiated the build
+#   _user      : The username (fed ID) of the user who initiated the build
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.
@@ -20,18 +21,12 @@
 #   _build_name: The base name to use for log files etc.
 #
 
-
-ReportFailure()
-{
-    { [ -f "$1" ] && cat $1 || echo $*; } |
-    mail -s "Build Errors: $_area $_module $_version"         $_email
-    exit 2
-}
-
 # Set up environment
 DLS_EPICS_RELEASE=${_epics}
 source /dls_sw/etc/profile
 build_dir=${_build_dir}
+
+SysLog info "Building etc in ${build_dir}"
 
 # Checkout module
 mkdir -p $build_dir                         || ReportFailure "Can not mkdir $build_dir"
@@ -45,6 +40,9 @@ else
 fi
 
 if [ -e Makefile ] ; then
-    make clean
-    make
+    SysLog info "Running make"
+    make clean || ReportFailure "make clean failed"
+    make       || ReportFailure "make failed"
 fi
+
+SysLog info "Build complete"

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # ******************************************************************************
 # 
 # Script to build a Diamond production module for support, ioc or matlab areas
@@ -7,6 +8,7 @@
 # dls-release mechanism. These variables are:
 #
 #   _email     : The email address of the user who initiated the build
+#   _user      : The username (fed ID) of the user who initiated the build
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.
@@ -18,14 +20,6 @@
 #   _force     : Force the build (i.e. rebuild even if already exists)
 #   _build_name: The base name to use for log files etc.
 #
-
-
-ReportFailure()
-{
-    { [ -f "$1" ] && cat $1 || echo $*; } |
-    mail -s "Build Errors: $_area $_module $_version"         $_email
-    exit 2
-}
 
 # Uncomment the following for tracing
 # set -o xtrace
@@ -56,17 +50,24 @@ case "$OS_VERSION" in
         ReportFailure "OS Version ${OS_VERSION} not handled"
 esac
 
+SysLog debug "os_version=${OS_VERSION} python=${PYTHON} install_dir=${INSTALL_DIR} tools_dir=${TOOLS_DIR} prefix=${PREFIX} build_dir=${build_dir}"
+
 # Checkout module
 mkdir -p $build_dir || ReportFailure "Can not mkdir $build_dir"
 cd $build_dir       || ReportFailure "Can not cd to $build_dir"
 
 if [[ "${_svn_dir:-undefined}" == "undefined" ]] ; then
     if [ ! -d $_version ]; then
+        SysLog info "Cloning repo: " $_git_dir
         git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        SysLog info "checkout version tag: " $_version
         ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
     elif [ "$_force" == "true" ] ; then
+        SysLog info "Force: removing previous version: " ${PWD}/$_version
         rm -rf $_version                            || ReportFailure "Can not rm $_version"
+        SysLog info "Cloning repo: " $_git_dir
         git clone --depth=100 $_git_dir $_version   || ReportFailure "Can not clone  $_git_dir"
+        SysLog info "checkout version tag: " $_version
         ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version )  || ReportFailure "Can not checkout $_version"
     elif [[ (( $(git status -uno --porcelain | wc -l) != 0 )) ]]; then
         ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
@@ -96,15 +97,15 @@ fi
 case "$OS_VERSION" in
     4)
         # Modify setup.py
-        mv setup.py setup.py.vcs || { echo Can not move setup.py to setup.py.vcs; exit 1; }
+        mv setup.py setup.py.vcs || ReportFailure "Can not move setup.py to setup.py.vcs"
         cat <<EOF > setup.py
 # The following line was added by the release script
 version = $(echo ${_version} | sed 's/-/./g')
 EOF
-        cat setup.py.vcs >> setup.py || { echo Can not edit setup.py; exit 1; }
+        cat setup.py.vcs >> setup.py || ReportFailure "Can not edit setup.py"
         ;;
     *)
-        cat <<EOF > Makefile.private || { echo Cannot write to Makefile.private; exit 1; }
+        cat <<EOF > Makefile.private || ReportFailure "Cannot write to Makefile.private"
 # Overrides for release info
 PREFIX = ${PREFIX}
 PYTHON=${PYTHON}
@@ -118,6 +119,7 @@ esac
 error_log=${_build_name}.err
 build_log=${_build_name}.log
 status_log=${_build_name}.sta
+SysLog info "Starting build. Build log: ${PWD}/${build_log} errors: ${PWD}/${error_log}"
 {
     {
         make clean && make
@@ -125,12 +127,14 @@ status_log=${_build_name}.sta
 
         # This is a bit of a hack to only install in production builds
         if  [[ "$build_dir" =~ "/prod/" && "$(cat $status_log)" == "0" ]] ; then
+            SysLog info "Doing make install in prod"
             make install
             echo $? >$status_log
 
             # If successful, run make-defaults
             if (( ! $(cat $status_log) )) ; then
                 TOOLS_BUILD=/dls_sw/prod/etc/build/tools_build
+                SysLog info "Running make-defaults" $TOOLS_DIR $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
                 $TOOLS_BUILD/make-defaults $TOOLS_DIR $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
             fi
         fi
@@ -144,7 +148,10 @@ status_log=${_build_name}.sta
 if (( $(cat $status_log) != 0 )) ; then
     ReportFailure $error_log
 elif (( $(stat -c%s $error_log) != 0 )) ; then
-    cat $error_log | mail -s "Build Errors: $_area $_module $_version"         $_email
-elif [ -e documentation/Makefile ]; then 
-    make -C documentation
+    cat $error_log | mail -s "Build Errors: $_area $_module $_version" $_email || SysLog err "Failed to email build errors"
+elif [ -e documentation/Makefile ]; then
+    SysLog info "Building documentation"
+    make -C documentation || ReportFailure "Documentation build failed"
 fi
+
+SysLog info "Build complete"

--- a/dls_ade/dlsbuild_scripts/Linux/support.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/support.sh
@@ -22,14 +22,6 @@
 #   _build_name: The base name to use for log files etc.
 #
 
-
-ReportFailure()
-{
-    { [ -f "$1" ] && cat $1 || echo $*; } |
-    mail -s "Build Errors: $_area $_module $_version" $_email
-    exit 2
-}
-
 # Set up environment
 DLS_EPICS_RELEASE=${_epics}
 source /dls_sw/etc/profile

--- a/dls_ade/dlsbuild_scripts/Linux/support.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/support.sh
@@ -9,6 +9,7 @@
 # dls-release mechanism. These variables are:
 #
 #   _email     : The email address of the user who initiated the build
+#   _user      : The username (fed ID) of the user who initiated the build
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -9,6 +9,7 @@
 # dls-release mechanism. These variables are:
 #
 #   _email     : The email address of the user who initiated the build
+#   _user      : The username (fed ID) of the user who initiated the build
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -42,18 +42,18 @@ build_dir=$_build_dir/RHEL$OS_VERSION-$(uname -m)
 mkdir -p $build_dir/${_module} || ReportFailure "Can not mkdir $build_dir/${_module}"
 cd $build_dir/${_module} || ReportFailure "Can not cd to $build_dir/${_module}"
 
-GrayLog debug "version dir: " `pwd`/$_version
+SysLog debug "version dir: " ${PWD}/$_version
 
 # If force, remove existing version directory (whether or not it exists)
 if [ "$_force" == "true" ]; then
-    GrayLog info "Force: removing previous version: " `pwd`/$_version
+    SysLog info "Force: removing previous version: " ${PWD}/$_version
     rm -rf $_version || ReportFailure "Can not rm $_version"
 fi
 
 if [ ! -d $_version ]; then
-    GrayLog info "Cloning repo: " $_git_dir
+    SysLog info "Cloning repo: " $_git_dir
     git clone --depth=100 $_git_dir $_version || ReportFailure "Can not clone  $_git_dir"
-    GrayLog info "Checking out version tag: " $_version
+    SysLog info "Checking out version tag: " $_version
     ( cd $_version && git fetch --depth=1 origin tag $_version && git checkout $_version ) || ReportFailure "Can not checkout $_version"
 elif (( $(git status -uno --porcelain | grep -Ev "M.*configure/RELEASE$" | wc -l) != 0)) ; then
     ReportFailure "Directory $build_dir/$_version not up to date with $_git_dir"
@@ -78,14 +78,14 @@ TOOLS_SUPPORT=$TOOLS_ROOT" "$release_file"
 fi
 
 # Build
-GrayLog info "Building tool. Build log: ${PWD}/${_version}/${_build_name}.log"
+SysLog info "Building tool. Build log: ${PWD}/${_version}/${_build_name}.log"
 $TOOLS_BUILD/build_program -n $_build_name ${_version}
 
 if (( $(cat ${_version}/${_build_name}.sta) != 0 )) ; then
     ReportFailure ${PWD}/${_version}/${_build_name}.log
 fi
 
-GrayLog info "make-defaults: " $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
+SysLog info "make-defaults: " $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
 $TOOLS_BUILD/make-defaults $build_dir $TOOLS_BUILD/RELEASE.RHEL$OS_VERSION-$(uname -m)
 
-GrayLog info "Build complete"
+SysLog info "Build complete"

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -20,16 +20,6 @@
 #   _area      : The build area
 #   _force     : Force the build (i.e. rebuild even if already exists)
 #   _build_name: The base name to use for log files etc.
-#
-
-
-ReportFailure()
-{
-    { [ -f "$1" ] && cat $1 || echo $*; } |
-    mail -s "Build Errors: $_area $_module $_version" $_email
-    exit 2
-}
-
 
 # Set up environment
 DLS_EPICS_RELEASE=${_epics}

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -5,7 +5,7 @@
 #  _dls_syslog_server_port : The port of the _dls_syslog_server to send messages to
 
 # Arguments: 
-#     1) log level. Valid levels are: alert, crit, debug, emerg, err, info, notice, warning
+#     1) log level. Valid levels are: alert, crit, err, warn, notice, info, debug
 #     2) Message
 SysLog()
 {
@@ -19,9 +19,12 @@ SysLog()
     # assuming log facility 'local2'.
     case "${syslog_level_str}" in
     alert)
+      PRI=145
+      ;;
+    crit)
       PRI=146
       ;;
-    crit|err*)
+    err*)
       PRI=147
       ;;
     warn*)
@@ -45,7 +48,8 @@ SysLog()
     # Fail safe implmented so that different logging mechanisms are tried in order, catching failures:
     #    1: dls-logger (requires module controls-tools to be pre-loaded)
     #    2: netcat (nc)
-    #    3:
+    #    3: logger (to local syslog)
+    #    4: echo (to stdout. Final, safe option if all else fails)
     echo ${syslog_message} |
     dls-logger \
     --tag dcs_build_job-$(uname -m) \

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Arguments: 
+#     1) log level. Valid levels are: alert, crit, debug, emerg, err, info, notice, warning
+#     2) Message
+GrayLog()
+{
+    echo ${@:2} |
+    /dls_sw/prod/tools/RHEL6-x86_64/util-linux/2-30-1/prefix/bin/logger \
+    --tag dcs_build_server \
+    -s -d -p local2.$1 \
+    -n cs03r-sc-serv-30 -P 5150 \
+    --rfc5424 \
+    --sd-id dcs@32121 \
+      --sd-param build_job_parameters=\"build_name=$_build_name\ area=$_area\ module=$_module\ version=$_version\ email=$_email\ username=$_user\" \
+    || echo "Build server error. logger failed:" $_build_name
+}
+
+ReportFailure()
+{
+    { [ -f "$1" ] && cat $1 || echo $*; } |
+    mail -s "Build Errors: $_area $_module $_version" $_email || echo "Build server error. mail failed:" $_build_name
+    GrayLog err "Build job failed: " $1
+    exit 2
+}
+

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -3,11 +3,11 @@
 # Arguments: 
 #     1) log level. Valid levels are: alert, crit, debug, emerg, err, info, notice, warning
 #     2) Message
-GrayLog()
+SysLog()
 {
     echo ${@:2} |
     /dls_sw/prod/tools/RHEL6-x86_64/util-linux/2-30-1/prefix/bin/logger \
-    --tag dcs_build_server \
+    --tag dcs_build_server-$(uname -m) \
     -s -d -p local2.$1 \
     -n cs03r-sc-serv-30 -P 5150 \
     --rfc5424 \
@@ -20,7 +20,7 @@ ReportFailure()
 {
     { [ -f "$1" ] && cat $1 || echo $*; } |
     mail -s "Build Errors: $_area $_module $_version" $_email || echo "Build server error. mail failed:" $_build_name
-    GrayLog err "Build job failed: " $1
+    SysLog err "Build job failed: " $*
     exit 2
 }
 

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
+# Expected pre-defined variables are:
+#  _dls_syslog_server      : The address of the server to send syslog messages to
+#  _dls_syslog_server_port : The port of the _dls_syslog_server to send messages to
+
 # Arguments: 
 #     1) log level. Valid levels are: alert, crit, debug, emerg, err, info, notice, warning
 #     2) Message
 SysLog()
 {
-    local dls_syslog_server=cs03r-sc-serv-30
-    local dls_syslog_server_port=5150
+    local dls_syslog_server=${_dls_syslog_server}
+    local dls_syslog_server_port=${_dls_syslog_server_port}
 
     local syslog_level_str=$1
     local syslog_message=${@:2}

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -6,8 +6,8 @@
 SysLog()
 {
     echo ${@:2} |
-    /dls_sw/prod/tools/RHEL6-x86_64/util-linux/2-30-1/prefix/bin/logger \
-    --tag dcs_build_server-$(uname -m) \
+    logger \
+    --tag dcs_build_job-$(uname -m) \
     -s -d -p local2.$1 \
     -n cs03r-sc-serv-30 -P 5150 \
     --rfc5424 \

--- a/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/utils_template.sh
@@ -5,15 +5,26 @@
 #     2) Message
 SysLog()
 {
-    echo ${@:2} |
-    logger \
+    local dls_syslog_server=cs03r-sc-serv-30
+    local dls_syslog_server_port=5150
+
+    local syslog_level_str=$1
+    local syslog_message=${@:2}
+
+    # Send the log message somewhere.
+    # Fail safe implmented so that different logging mechanisms are tried in order, catching failures:
+    #    1: dls-logger (requires module controls-tools to be pre-loaded)
+    #    2: netcat (nc)
+    #    3:
+    echo ${syslog_message} |
+    dls-logger \
     --tag dcs_build_job-$(uname -m) \
     -s -d -p local2.$1 \
-    -n cs03r-sc-serv-30 -P 5150 \
+    -n ${dls_syslog_server} -P ${dls_syslog_server_port} \
     --rfc5424 \
     --sd-id dcs@32121 \
       --sd-param build_job_parameters=\"build_name=$_build_name\ area=$_area\ module=$_module\ version=$_version\ email=$_email\ username=$_user\" \
-    || echo "Build server error. logger failed:" $_build_name
+    || echo "(logger failed) Build server error:" $_build_name ${syslog_message}
 }
 
 ReportFailure()

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -53,8 +53,8 @@ default_config = {
             "level": "INFO",
             # Obviously a DLS-specific configuration: the graylog server address and port
             # Graylog2 cluster. Input: "Load-Balanced GELF TCP"
-            "host": "graylog2",
-            "port": 12201,
+            "host": os.getenv('ADE_GELFLOG_SERVER', "graylog2.diamond.ac.uk"),
+            "port": int(os.getenv('ADE_GELFLOG_SERVER_PORT', '12201')),
             "debug": True,
             #  The following custom fields will be disabled if setting this False
             "include_extra_fields": True,


### PR DESCRIPTION
Adding support for the (Linux) build servers to log messages from the build jobs directly to our graylog2 syslog server.

The server address+port both for python/gelf and script/syslog messages can be overridden by environment variables. README.md updated with instructions.

By default the build server scripts will log to the "Controls Services" input and python scripts to the generic, non-application-specific GELF TCP input as described here: https://confluence.diamond.ac.uk/x/7cSNB

The bash SysLog function will attempt several methods for sending log messages to the syslog server, starting with "dls-logger", and ending an "echo" command (to stdout only) if all else fails. This is an attempt to cater for potentially changing environment and ending with a fail-safe option so that the SysLog function can not cause the script to error and exit.