### PR TITLE
Refactoring environment constants

### DIFF
--- a/dls_ade/constants.py
+++ b/dls_ade/constants.py
@@ -1,0 +1,38 @@
+import os
+
+# Root directory to perform build operations.
+# For testing/development, this can be changed to redirect build scripts away
+# from the build server, e.g. a user's home directory. Set the environment
+# variables DLSBUILD_ROOT_DIR and/or DLSBUILD_WIN_ROOT_DIR to override the
+# default location.
+# Be sure that the root dir contains the expected directories (e.g. work/etc/build/queue).
+DLSBUILD_ROOT_DIR = os.getenv("DLSBUILD_ROOT_DIR", "/dls_sw")
+DLSBUILD_WIN_ROOT_DIR = os.getenv("DLSBUILD_WIN_ROOT_DIR", "W:/")
+
+LDAP_SERVER_URL = 'ldap://altfed.cclrc.ac.uk'
+GIT_ROOT = "dascgitolite@dasc-git.diamond.ac.uk"
+
+_gelflog_server_addr = os.getenv('ADE_GELFLOG_SERVER', "graylog2.diamond.ac.uk:12201").split(':')
+GELFLOG_SERVER = _gelflog_server_addr[0]
+GELFLOG_SERVER_PORT = _gelflog_server_addr[1]
+
+_syslog_server = os.getenv("ADE_SYSLOG_SERVER", "{}:12209".format(GELFLOG_SERVER)).split(':')
+SYSLOG_SERVER = _syslog_server[0]
+SYSLOG_SERVER_PORT = _syslog_server[1]
+
+BUILD_SERVERS = {
+    "Linux": {
+        "redhat6-x86_64": ["R3.14.12.3"],
+        "redhat7-x86_64": ["R3.14.12.7"]
+    },
+    "Windows": {
+        "windows6-x86"   : ["R3.14.12.3"],
+        "windows6-AMD64" : ["R3.14.12.3"]
+    }
+}
+SERVER_SHORTCUT = {
+    "6": "redhat6-x86_64",
+    "7": "redhat7-x86_64",
+    "32": "windows6-x86",
+    "64": "windows6-AMD64"}
+

--- a/dls_ade/dls_module_contacts.py
+++ b/dls_ade/dls_module_contacts.py
@@ -23,6 +23,7 @@ from dls_ade import path_functions as pathf
 from dls_ade import Server
 from dls_ade.exceptions import FedIdError
 from dls_ade import logconfig
+from dls_ade.constants import LDAP_SERVER_URL
 
 # Optional but useful in a library or non-main module:
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -138,7 +139,7 @@ def lookup_contact_name(fed_id):
     """
 
     # Set up ldap search parameters
-    l = ldap.initialize('ldap://altfed.cclrc.ac.uk')
+    l = ldap.initialize(LDAP_SERVER_URL)
     basedn = "dc=fed,dc=cclrc,dc=ac,dc=uk"
     search_filter = "(&(cn={}))".format(fed_id)
     search_attribute = ["givenName", "sn"]

--- a/dls_ade/gitoliteserver.py
+++ b/dls_ade/gitoliteserver.py
@@ -4,11 +4,10 @@ import tempfile
 import subprocess
 import logging
 
+from dls_ade.constants import GIT_ROOT
 from dls_ade.gitserver import GitServer
-from dls_ade import path_functions as pathf
 from dls_ade.vcs_git import git
 
-GIT_ROOT = "dascgitolite@dasc-git.diamond.ac.uk"
 GIT_SSH_ROOT = "ssh://" + GIT_ROOT + "/"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/dls_ade/gitoliteserver_test.py
+++ b/dls_ade/gitoliteserver_test.py
@@ -3,7 +3,7 @@ from pkg_resources import require
 require("mock")
 from mock import patch, MagicMock  # @UnresolvedImport
 
-from dls_ade.gitoliteserver import GitoliteServer
+from dls_ade.gitoliteserver import GitoliteServer, GIT_SSH_ROOT
 
 
 class IsServerRepoTest(unittest.TestCase):
@@ -61,7 +61,7 @@ class CreateRemoteRepoTest(unittest.TestCase):
 
         mock_is_server_repo.assert_called_once_with("test_destination")
         mock_clone_from.assert_called_once_with(
-            'ssh://dascgitolite@dasc-git.diamond.ac.uk/test_destination', "tempdir")
+            '{git_ssh_root}test_destination'.format(git_ssh_root=GIT_SSH_ROOT), "tempdir")
         mock_mkdtemp.assert_called_once_with()
         mock_rmtree.assert_called_once_with("tempdir")
 

--- a/dls_ade/logconfig.py
+++ b/dls_ade/logconfig.py
@@ -11,7 +11,7 @@ import json
 import logging.config
 import getpass
 import threading
-
+from dls_ade.constants import GELFLOG_SERVER, GELFLOG_SERVER_PORT
 
 default_config = {
     "version": 1,
@@ -53,8 +53,8 @@ default_config = {
             "level": "INFO",
             # Obviously a DLS-specific configuration: the graylog server address and port
             # Graylog2 cluster. Input: "Load-Balanced GELF TCP"
-            "host": os.getenv('ADE_GELFLOG_SERVER', "graylog2.diamond.ac.uk"),
-            "port": int(os.getenv('ADE_GELFLOG_SERVER_PORT', '12201')),
+            "host": GELFLOG_SERVER,
+            "port": int(GELFLOG_SERVER_PORT),
             "debug": True,
             #  The following custom fields will be disabled if setting this False
             "include_extra_fields": True,


### PR DESCRIPTION
A minor refactoring: moving global or environment variables into a single location (constants.py).

Things like git repo server address, syslog server, etc. should live in a single location to make it easier for future developers to track and/or change.