### PR TITLE
dls-start-new-module: Add CSS template

### DIFF
--- a/dls_ade/cookiecutter_templates/CSS_IOC/cookiecutter.json
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+  "project_name": "BL01-UI-IOC-01",
+  "domain": "{{cookiecutter.project_name.split('-')[0]}}", 
+  "technical_area": "{{cookiecutter.project_name.split('-')[1]}}", 
+  "ioc_number": "{{cookiecutter.project_name.split('-')[3]}}"
+}

--- a/dls_ade/cookiecutter_templates/CSS_IOC/cookiecutter.json
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "project_name": "BL01-UI-IOC-01",
-  "domain": "{{cookiecutter.project_name.split('-')[0]}}", 
-  "technical_area": "{{cookiecutter.project_name.split('-')[1]}}", 
-  "ioc_number": "{{cookiecutter.project_name.split('-')[3]}}"
+  "app_name": "{{cookiecutter.project_name}}",
+  "domain": "{{cookiecutter.app_name.split('-')[0]}}",
+  "technical_area": "{{cookiecutter.app_name.split('-')[1]}}",
+  "ioc_number": "{{cookiecutter.app_name.split('-')[3]}}"
 }

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/Makefile
@@ -1,0 +1,17 @@
+#Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), configure)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+
+define DIR_template
+ $(1)_DEPEND_DIRS = configure
+endef
+$(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
+
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+include $(TOP)/configure/RULES_TOP
+
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/CONFIG
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/CONFIG
@@ -1,0 +1,30 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+-include $(CONFIG)/CONFIG.Dls
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/CONFIG_SITE
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/CONFIG_SITE
@@ -1,0 +1,33 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building anyway if conflicts are found.
+CHECK_RELEASE = NO
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+CROSS_COMPILER_TARGET_ARCHS = 
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</path/name/to/install/top>
+
+# Set this when your IOC and the host use different paths
+#   to access the application. This will be needed to boot
+#   from a Microsoft FTP server or with some NFS mounts.
+# You must rebuild in the iocBoot directory for this to
+#   take effect.
+#IOCS_APPL_TOP = </IOC/path/to/application/top>

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RELEASE
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RELEASE
@@ -1,0 +1,51 @@
+# RELEASE - Location of external support modules
+ #
+# IF YOU MAKE ANY CHANGES to this file you must subsequently
+# do a "gnumake rebuild" in this application's top level
+# directory.
+#
+# The build process does not check dependencies against files
+# that are outside this application, thus you should do a
+# "gnumake rebuild" in the top level directory after EPICS_BASE
+# or any other external module pointed to below is rebuilt.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file should ONLY define paths to other support modules,
+# or include statements that pull in similar RELEASE files.
+# Build settings that are NOT module paths should appear in a
+# CONFIG_SITE file.
+
+TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+PROD_IOCS=/dls_sw/prod/R3.14.12.3/ioc/{{cookiecutter.domain}}
+WORK_IOCS=/dls_sw/work/R3.14.12.3/ioc/{{cookiecutter.domain}}
+BUILDER_IOCS=/dls_sw/work/R3.14.12.3/support/{{cookiecutter.domain}}-BUILDER/iocs
+WORK_SUPPORT=/dls_sw/work/R3.14.12.3/support
+PROD_SUPPORT=/dls_sw/prod/R3.14.12.3/support
+
+BLGUI=      $(PROD_SUPPORT)/BLGui/3-14
+
+# Add the required IOC's
+# VA02=       /dls_sw/prod/R3.14.12.3/ioc/BL21I/BL21I-VA-IOC-02/3-6
+
+vacuumSpace=$(PROD_SUPPORT)/vacuumSpace/4-2
+dlsPLC=     $(PROD_SUPPORT)/dlsPLC/1-46
+SLIT=       $(PROD_SUPPORT)/slit/3-20
+GDA=        $(PROD_SUPPORT)/gda/2014-1
+CALC=       $(PROD_SUPPORT)/calc/3-1
+
+DEVIOCSTATS=$(PROD_SUPPORT)/devIocStats/3-1-14dls2-4
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ=$(EPICS_BASE)/../modules/soft/seq
+
+# EPICS_BASE usually appears last so other apps can override stuff:
+EPICS_BASE=/dls_sw/epics/R3.14.12.3/base
+
+# Set RULES here if you want to take build rules from somewhere
+# other than EPICS_BASE:
+#RULES=/path/to/epics/support/module/rules/x-y
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES
@@ -1,0 +1,7 @@
+# RULES
+
+-include $(CONFIG)/RULES.Dls
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES.ioc
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES_DIRS
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES_TOP
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/color.def
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/color.def
@@ -1,0 +1,72 @@
+# Alarm colours
+Minor = 255, 241, 0
+Major = 255, 0, 0
+Invalid = 255, 255, 255
+Disconnected = 255, 255, 255
+
+# Widget colours
+Canvas = 200, 200, 200
+Button: BG = 205, 205, 205
+Button: On = 190, 190, 190
+Controller: FG = 0, 0, 196
+Related Display: FG = 128, 64, 0
+Text: FG = 0, 0, 0
+Exit: FG = 196, 0, 196
+Monitor: BG = 64, 64, 64
+Monitor: FG = 96, 255, 96
+
+# LED colours
+Red LED: On = 255, 0, 0
+Red LED: Off = 96, 0, 0
+Yellow LED: On = 255, 255, 0
+Yellow LED: Off = 96, 96, 0
+Green LED: On = 0, 255, 0
+Green LED: Off = 0, 96, 0
+Blue LED: On = 0, 255, 255
+Blue LED: Off = 0, 96, 96
+
+# Generic colours
+White = 255, 255, 255
+Grey 90% = 230, 230, 230
+Grey 75% = 192, 192, 192
+Grey 65% = 166, 166, 166
+Grey 50% = 128, 128, 128
+Grey 40% = 102, 102, 102
+Grey 25% = 64, 64, 64
+Black = 0, 0, 0
+Red = 255, 0, 0
+Mid Red = 196, 0, 0
+Dark Red = 128, 0, 0
+Yellow = 255, 255, 0
+Mid Yellow = 196, 196, 0
+Dark Yellow = 128, 128, 0
+Green = 0, 255, 0
+Mid Green = 0, 196, 0
+Dark Green = 0, 128, 0
+Cyan = 0, 255, 255
+Mid Cyan = 0, 196, 196
+Dark Cyan = 0, 128, 128
+Blue = 0, 0, 255
+Mid Blue = 0, 0, 196
+Dark Blue = 0, 0, 128
+Purple = 255, 0, 255
+Mid Purple = 196, 0, 196
+Dark Purple = 128, 0, 128
+Amber = 255, 196, 0
+Orange = 255, 196, 96
+Light Brown = 196, 128, 64
+Dark Brown = 128, 96, 32
+
+# Title colours
+CO title = 169, 210, 240
+EA title = 135, 216, 135
+VA title = 202, 223, 159
+MA title = 185, 198, 184
+TI title = 210, 201, 172
+MO title = 115, 212, 216
+CG title = 158, 207, 207
+RS title = 225, 193, 144
+RF title = 184, 181, 198
+MP title = 238, 205, 224
+DI title = 198, 181, 198
+PS title = 255, 150, 168

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/font.def
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/font.def
@@ -1,0 +1,9 @@
+Header 1 = Arial-bold-18
+Header 2 = Arial-bold-14
+Header 3 = Arial-bold-12
+Default = Arial-regular-11
+Default Bold = Arial-bold-11
+Label Small = Arial-regular-10
+Fine Print = Arial-regular-9
+Monospace = Monospace-regular-10
+Monospace Bold = Monospace-bold-10

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/perspective_{{cookiecutter.domain}}.xmi
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/perspective_{{cookiecutter.domain}}.xmi
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ASCII"?>
+<advanced:Perspective xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:advanced="http://www.eclipse.org/ui/2010/UIModel/application/ui/advanced" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmi:id="_e0bXsHFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.OPIRuntime.perspective.{{cookiecutter.domain}}" selectedElement="_e0bXsXFCEeeKjIqW3U0Cqg" label="{{cookiecutter.domain}}" iconURI="platform:/plugin/org.csstudio.opibuilder/icons/OPIBuilder.png" tooltip="{{cookiecutter.domain}}">
+  <persistedState key="persp.hiddenItems" value="persp.hideToolbarSC:print,persp.hideToolbarSC:org.eclipse.ui.edit.text.toggleShowSelectedElementOnly,"/>
+  <tags>persp.actionSet:org.csstudio.opibuilder.actionSet</tags>
+  <tags>persp.actionSet:org.csstudio.opibuilder.editor.actionSet</tags>
+  <tags>persp.actionSet:org.eclipse.search.searchActionSet</tags>
+  <tags>persp.actionSet:org.eclipse.ui.actionSet.keyBindings</tags>
+  <tags>persp.actionSet:org.eclipse.ui.actionSet.openFiles</tags>
+  <tags>persp.viewSC:org.eclipse.ui.console.ConsoleView</tags>
+  <tags>persp.viewSC:org.eclipse.ui.views.ResourceNavigator</tags>
+  <tags>persp.perspSC:org.csstudio.utility.product.CSStudioPerspective</tags>
+  <tags>persp.perspSC:org.csstudio.opibuilder.opieditor</tags>
+  <tags>persp.perspSC:org.csstudio.opibuilder.OPIRuntime.perspective</tags>
+  <tags>persp.perspSC:org.csstudio.trends.databrowser.Perspective</tags>
+  <children xsi:type="basic:PartSashContainer" xmi:id="_e0bXsXFCEeeKjIqW3U0Cqg" selectedElement="_e0bXtnFCEeeKjIqW3U0Cqg" horizontal="true">
+    <children xsi:type="basic:PartStack" xmi:id="_e0bXsnFCEeeKjIqW3U0Cqg" elementId="LEFT" visible="false" containerData="2500" selectedElement="_e0bXtHFCEeeKjIqW3U0Cqg">
+      <tags>Minimized</tags>
+      <children xsi:type="advanced:Placeholder" xmi:id="_e0bXs3FCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewLEFT:*" toBeRendered="false"/>
+      <children xsi:type="advanced:Placeholder" xmi:id="_e0bXtHFCEeeKjIqW3U0Cqg" elementId="org.eclipse.ui.views.ResourceNavigator"/>
+      <children xsi:type="advanced:Placeholder" xmi:id="_e0bXtXFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiShellSummary">
+        <tags>NoClose</tags>
+      </children>
+    </children>
+    <children xsi:type="basic:PartSashContainer" xmi:id="_e0bXtnFCEeeKjIqW3U0Cqg" containerData="7500" selectedElement="_e0bXuXFCEeeKjIqW3U0Cqg">
+      <children xsi:type="basic:PartStack" xmi:id="_e0bXt3FCEeeKjIqW3U0Cqg" elementId="TOP" toBeRendered="false" containerData="2500">
+        <children xsi:type="advanced:Placeholder" xmi:id="_e0bXuHFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewTOP:*" toBeRendered="false"/>
+      </children>
+      <children xsi:type="basic:PartSashContainer" xmi:id="_e0bXuXFCEeeKjIqW3U0Cqg" containerData="7500" selectedElement="_e0bXunFCEeeKjIqW3U0Cqg">
+        <children xsi:type="basic:PartSashContainer" xmi:id="_e0bXunFCEeeKjIqW3U0Cqg" containerData="7500" selectedElement="_e0bXvHFCEeeKjIqW3U0Cqg" horizontal="true">
+          <children xsi:type="advanced:Placeholder" xmi:id="_e0bXu3FCEeeKjIqW3U0Cqg" elementId="org.eclipse.ui.editorss" visible="false" containerData="5000">
+            <tags>Minimized</tags>
+          </children>
+          <children xsi:type="basic:PartSashContainer" xmi:id="_e0bXvHFCEeeKjIqW3U0Cqg" containerData="5000" selectedElement="_e0bXvXFCEeeKjIqW3U0Cqg" horizontal="true">
+            <children xsi:type="basic:PartStack" xmi:id="_e0bXvXFCEeeKjIqW3U0Cqg" elementId="DEFAULT_VIEW" containerData="7875" selectedElement="_e0bXvnFCEeeKjIqW3U0Cqg">
+              <tags>active</tags>
+              <tags>noFocus</tags>
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXvnFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiView:4c81aab8-1820-490b-94ab-1c2ff76fbd79">
+                <persistedState key="memento" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;view factory_id=&quot;org.csstudio.opibuilder.runmode.RunnerInputFactory&quot;>&#xA;&lt;input path=&quot;/{{cookiecutter.domain}}/{{cookiecutter.domain}}App_opi/{{cookiecutter.domain}}-hardware.opi&quot;/>&#xA;&lt;/view>"/>
+              </children>
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXv3FCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiView:e5647b6f-edc4-464f-a767-bc38a74d54a9" toBeRendered="false">
+                <persistedState key="memento" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;view factory_id=&quot;org.csstudio.opibuilder.runmode.RunnerInputFactory&quot;>&#xA;&lt;input macro=&quot;&amp;quot;true&amp;quot;,&amp;quot;ISBL=&amp;quot;&quot; path=&quot;/{{cookiecutter.domain}}/{{cookiecutter.domain}}App_opi/JBPM1.opi&quot;/>&#xA;&lt;/view>"/>
+              </children>
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXwHFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiView:*" toBeRendered="false"/>
+            </children>
+            <children xsi:type="basic:PartStack" xmi:id="_e0bXwXFCEeeKjIqW3U0Cqg" elementId="RIGHT" toBeRendered="false" containerData="2125">
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXwnFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewRIGHT:87fb80bc-8621-4815-9643-12e649ee68f8" toBeRendered="false">
+                <persistedState key="memento" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;view factory_id=&quot;org.csstudio.opibuilder.runmode.RunnerInputFactory&quot;>&#xA;&lt;input macro=&quot;&amp;quot;true&amp;quot;,&amp;quot;LCID=LCID_13&amp;quot;,&amp;quot;ISBL=&amp;quot;,&amp;quot;P={{cookiecutter.domain}}-DI-BPM-01&amp;quot;,&amp;quot;R=:ARR:&amp;quot;,&amp;quot;DESC=Array&amp;quot;&quot; path=&quot;/{{cookiecutter.domain}}/ADApp_opi/array_detail.opi&quot;/>&#xA;&lt;/view>"/>
+              </children>
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXw3FCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewRIGHT:eed9941f-4cc3-47e8-b7e2-56f5bd8638ca" toBeRendered="false">
+                <persistedState key="memento" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;view factory_id=&quot;org.csstudio.opibuilder.runmode.RunnerInputFactory&quot;>&#xA;&lt;input macro=&quot;&amp;quot;true&amp;quot;,&amp;quot;LCID=LCID_13&amp;quot;,&amp;quot;ISBL=&amp;quot;,&amp;quot;P={{cookiecutter.domain}}-DI-BPM-01&amp;quot;,&amp;quot;R=:ARR:&amp;quot;,&amp;quot;DESC=Array&amp;quot;&quot; path=&quot;/{{cookiecutter.domain}}/ADApp_opi/array_detail.opi&quot;/>&#xA;&lt;/view>"/>
+              </children>
+              <children xsi:type="advanced:Placeholder" xmi:id="_e0bXxHFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewRIGHT:*" toBeRendered="false"/>
+            </children>
+          </children>
+        </children>
+        <children xsi:type="basic:PartStack" xmi:id="_e0bXxXFCEeeKjIqW3U0Cqg" elementId="BOTTOM" containerData="2500" selectedElement="_e0bXyHFCEeeKjIqW3U0Cqg">
+          <children xsi:type="advanced:Placeholder" xmi:id="_e0bXxnFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiViewBOTTOM:*" toBeRendered="false"/>
+          <children xsi:type="advanced:Placeholder" xmi:id="_e0bXx3FCEeeKjIqW3U0Cqg" elementId="org.eclipse.ui.console.ConsoleView"/>
+          <children xsi:type="advanced:Placeholder" xmi:id="_e0bXyHFCEeeKjIqW3U0Cqg" elementId="org.csstudio.opibuilder.opiView:b9210e19-40d4-462f-a0cf-f4900150ceda">
+            <persistedState key="memento" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;view factory_id=&quot;org.csstudio.opibuilder.runmode.RunnerInputFactory&quot;>&#xA;&lt;input path=&quot;/{{cookiecutter.domain}}/{{cookiecutter.domain}}App_opi/synoptic.opi&quot;/>&#xA;&lt;/view>"/>
+          </children>
+        </children>
+      </children>
+    </children>
+  </children>
+</advanced:Perspective>

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/resetCSS
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/resetCSS
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+DIR=$(cd $(dirname "$0"); pwd)
+HOSTNAME=`hostname -s`
+# generate the beamline name from the folder we are in
+# (assumes this file is in etc. and  2 dirs above etc folder is the Beamline folder)
+BEAMLINE=$(basename $(cd $DIR/../..; pwd))
+WS=~/workspaces/cs-studio-$HOSTNAME-$BEAMLINE
+
+killall -9 cs-studio
+killall -9 /usr/bin/java
+
+
+if [ "$1" ==  "-r" ]
+then
+    # remove previous
+    echo "removing workspace $WS"
+    rm -fr $WS
+fi

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/saveWorkspace
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/saveWorkspace
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# tar up the current workspace 
+
+DIR=$(cd $(dirname "$0"); pwd) 
+HOSTNAME=`hostname -s`
+WS=~/workspaces/cs-studio-$HOSTNAME
+TAR=$DIR/workspaceStartup.tar
+
+echo "saving the workspace at $WS to $TAR"
+
+rm $DIR/workspaceStartup.tar
+cd $WS
+tar -cf $DIR/workspaceStartup.tar * .metadata
+
+
+
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/startGui
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/etc/startGui
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Run CSS up in a unique workspace 
+#
+# the first parameter is -r then remove workspace completely
+
+DIR=$(cd $(dirname "$0"); pwd)
+HOSTNAME=`hostname -s`
+WS=~/workspaces/cs-studio/$HOSTNAME
+
+if [ "$1" ==  "-r" ]
+then
+    # remove previous
+    echo "removing previous workspace $WS"
+    rm -fr $WS
+    shift
+fi
+
+$DIR/../bin/linux-x86_64/launch_gui $@
+
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(EPICS_BASE)/configure/RULES_DIRS
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/ioc{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/ioc{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+
+SCRIPTS=st{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.boot
+
+include $(TOP)/configure/RULES

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/ioc{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01/st{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.src
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/iocBoot/ioc{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01/st{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.src
@@ -1,0 +1,13 @@
+#!$(INSTALL)/bin/$(ARCH)/BL15J-BL-IOC-01
+
+cd "$(INSTALL)"
+
+## Register all support components
+dbLoadDatabase("dbd/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.dbd")
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_registerRecordDeviceDriver(pdbbase)
+
+## Load record instances
+dbLoadRecords("db/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.db")
+dbLoadRecords("db/{{cookiecutter.domain}}.db")
+
+iocInit()

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Db/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Db/Makefile
@@ -1,0 +1,34 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# In a Diamond IOC Application, build db files from
+# template files like this
+#
+DB += {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.db
+
+#----------------------------------------------------
+# In a Diamond IOC Application, build xml files from
+# database files like this
+#
+
+# List database files required.
+USES_DB += ../O.Common/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.db
+# USES_DB += $(VA02)/db/BL21I-VA-IOC-02_expanded.db
+
+DATA += {{cookiecutter.domain}}-gui.xml
+DATA += {{cookiecutter.domain}}.grp
+
+include $(TOP)/configure/RULES
+
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+
+{{cookiecutter.domain}}.grp: parser-output-{{cookiecutter.domain}}
+
+{{cookiecutter.domain}}-gui.xml: parser-output-{{cookiecutter.domain}}
+
+parser-output-{{cookiecutter.domain}} : $(USES_DB)
+	PYTHONPATH=/dls_sw/work/common/python/dls_epicsparser/prefix/lib/python2.7/site-packages /dls_sw/work/common/python/dls_epicsparser/prefix/bin/epicsparser.py $^ -r {{cookiecutter.domain}} -s 'ar,gui'> $@

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Db/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.substitutions
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Db/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.substitutions
@@ -1,0 +1,6 @@
+file $(DEVIOCSTATS)/db/ioc.db
+{
+pattern { IOCNAME, name }
+    { "{{cookiecutter.domain}}", "IOCS.{{cookiecutter.technical_area}}" }
+}
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/Makefile
@@ -1,0 +1,9 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *op*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/Makefile
@@ -1,0 +1,6 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ 
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *opi*))
+ 
+include $(TOP)/configure/RULES_DIRS

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/InsertNwsTop
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/InsertNwsTop
@@ -1,0 +1,4 @@
+#! /bin/bash
+IOC_TOP=$(readlink -m $(pwd)/../../../..)
+echo IOC Top is ${IOC_TOP}
+sed  -i s=TOP_OF_IOC=${IOC_TOP}= launch.nws

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/Makefile
@@ -1,0 +1,30 @@
+TOP = ../../..
+include $(TOP)/configure/CONFIG
+
+# these are options to create_gui.py
+allow_remove = no
+log_level = WARNING
+
+SCRIPTS += launch_gui
+SCRIPTS += launch.nws
+
+DATA += {{cookiecutter.domain}}-create-gui.xml
+DB += {{cookiecutter.domain}}.db
+
+include $(TOP)/configure/RULES
+
+{{cookiecutter.domain}}-create-gui.xml: launch_gui
+
+../O.Common/{{cookiecutter.domain}}.db: {{cookiecutter.domain}}.db
+	cp $< $@
+
+{{cookiecutter.domain}}.db: launch_gui
+launch.nws: launch_gui
+
+launch_gui: ../create_gui.py $(TOP)/configure/RELEASE $(TOP)/data/{{cookiecutter.domain}}-gui.xml $(wildcard ../*.opi)
+	$< --allow_remove=$(allow_remove) --log_level=$(log_level)
+	../InsertNwsTop
+
+clean::
+	rm -f $(shell grep -l 'Opening and saving this file in cs-studio will delete this comment and stop dls_xmlbuilder regenerating it' *.opi)
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/create_gui.py
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/create_gui.py
@@ -1,0 +1,198 @@
+#!/bin/env dls-python
+import sys, os
+import subprocess # For calling Xvfb
+import atexit
+
+# add the following for debugging
+# --log_level=DEBUG
+
+# run from gui_builder/dls_epicsparser source
+# ===========================================
+#sys.path.append("/dls_sw/work/common/python/dls_guibuilder")
+#sys.path.append("/dls_sw/work/common/python/dls_epicsparser")
+
+# run from COMPILED gui_builder/dls_epicsparser
+# =============================================
+# sys.path.append("/dls_sw/work/common/python/dls_guibuilder/prefix/lib/python2.7/site-packages")
+# sys.path.append("/dls_sw/work/common/python/dls_epicsparser/prefix/lib/python2.7/site-packages")
+
+# dls_epicsparser should be pulled in automatically from dls_guibuilder now
+# so no need to import it separately.
+from pkg_resources import require
+require("dls_guibuilder")
+
+# If we are running on a headless machine DISPLAY will be unset. So start Xvfb
+# (a virtual X window server) and point DISPLAY to it. This is required for
+# tkinter (which is used by dls_guibuilder for font rendering) to initialise
+# successfully.
+xvfbProcess = subprocess.Popen(["Xvfb", ":10"])
+
+try:
+    os.environ["DISPLAY"]
+except KeyError:
+    os.environ["DISPLAY"] = ":10"
+
+@atexit.register
+def killXvfb():
+    xvfbProcess.kill()
+
+from dls_guibuilder import GuiBuilder, Pv, BoyScreen
+
+gb = GuiBuilder()
+gb.parse_release('configure/RELEASE')
+gb.add_defs_from_xml('data/{{cookiecutter.domain}}-gui.xml')
+
+def add_rga(name, device):
+    s2 = BoyScreen("boyembed", "rgamv2App_opi/rga_embed.opi",
+                   macros="device=" + device)
+    s1 = BoyScreen("boycomponent", "rgamv2App_opi/rga.opi",
+                   macros="device=" + device)
+    sevr = Pv("sevr", device + ':STA')
+    gb.add_def(name, s1, s2, sevr)
+
+
+def add_fast_valve_gauge_interlock(name, device):
+    mlist = "device={},name={}".format(device, name)
+    s1 = BoyScreen("boyembed", "mks937bApp_opi/fvg_embed.opi", macros=mlist)
+    s2 = BoyScreen("boydetail", "mks937bApp_opi/fvg_detail.opi", macros=mlist)
+    sevr = Pv("sevr", device)
+    gb.add_def(name, s1, s2, sevr)
+
+
+# Add front end defs (we have to  manually describe the Gui elements since we have no IOC to refer to)
+def add_external_valve(name, device, macros):
+    macros = "device=%s,%s" % (device, macros)
+    s1 = BoyScreen("boyembed", "dlsPLCApp_opi/vacValve_embed_box.opi",
+                   macros=macros)
+    s2 = BoyScreen("boyembed", "dlsPLCApp_opi/vacValve_embed.opi",
+                   macros=macros)
+    s3 = BoyScreen("boydetail", "dlsPLCApp_opi/vacValve_detail.opi",
+                   macros=macros)
+    sevr = Pv("sevr", device + ':STA')
+    gb.add_def(name, s1, s2, s3, sevr)
+
+
+# Add definitions matching extra_def_format to the screen. This allows us to take widgets from separate component screen.
+def create_component_with_defs(name, P, extra_def_format, description,
+                               regex=False):
+    extra_defs = gb.find(name=extra_def_format, regex=regex)
+    component_defs = gb.create_dotted(name, P)
+    gb.create_component(name, P, defs=component_defs + extra_defs,
+                        description=description)
+
+add_external_valve('FE.V2', 'FE{{cookiecutter.domain[2:]}}-VA-VALVE-02',
+                   'DESC=FE Valve 2,valvetype=valve,name=FV2')
+add_external_valve('FE.Absorber', 'FE{{cookiecutter.domain[2:]}}-RS-ABSB-01',
+                   'DESC=FE Absorber,valvetype=absorber,name=FABS')
+add_external_valve('FE.Shutter', 'FE{{cookiecutter.domain[2:]}}-PS-SHTR-02',
+                   'DESC=FE Shutter,valvetype=shutter,name=FSHTR')
+add_external_valve('FE.PortShutter', 'FE{{cookiecutter.domain[2:]}}-PS-SHTR-01',
+                   'DESC=Port Shutter,valvetype=shutter,name=FPORT')
+
+# Create component screens
+gb.create_component('FE', '{{cookiecutter.domain}}-CS-FEND-01', description='Front End')
+
+# Make the synoptic
+definitions = gb.find_from_screen('synoptic.opi')
+synoptic = gb.create_screen(definitions, 'synoptic.opi')
+# REVIEW - the below is not working - to be investigated
+gb.add_def("Synoptic", synoptic)
+
+# create Vacuum Screens
+tees = [
+    ("SP1", "GAUGE1", "IMG1", "PIRG1", "IONP1", "RGA1"),
+    ("SP2", "GAUGE2", "IMG2", "PIRG2", "IONP2"),
+    ("SP3", "GAUGE3", "IMG3", "PIRG3", "IONP3", "RGA2"),
+    ("SP4", "GAUGE4", "IMG4", "PIRG4", "IONP4", "RGA3"),
+]
+vacDefs = gb.find(
+    screen_file=["*vacValve_embed.opi", '*ionp_embed.opi', "*space_embed.opi", "*gauge_embed.opi", "*img_embed.opi",
+                 "*pirg_embed.opi"])
+vacuumSummary = gb.create_screen(vacDefs, '{{cookiecutter.domain}}-vacuum.opi', style='vacuum', synoptic=synoptic, pump_tees=tees)
+
+# Make Hardware Status Screen 
+iocs = [
+    ("{{cookiecutter.domain}}-VA-IOC-01", "Vacuum"),
+    ("{{cookiecutter.domain}}-MO-IOC-01", "Motion"),
+]
+
+# some flags to control hardware status screen creation
+doHardwareStatus = True
+autoProcServControl = True
+
+# Create hardware status screens
+if doHardwareStatus:
+    ioc_defs = []
+    for ioc_name, ioc_desc in iocs:
+        procServs = gb.find(name="%s.*" % ioc_name, screen_file="*procServ*")
+        crateMons = gb.find(name="%s.*" % ioc_name, screen_file="*crateMon*")
+        if not autoProcServControl:
+            assert procServs + crateMons, "No procServ or crateMon element found for %s" % ioc_name
+        devIocStats = gb.find(name="%s.*" % ioc_name, screen_file="devIocStats*")
+        assert len(devIocStats) < 2, "More than 1 devIocStats element found for %s" % ioc_name
+        autoSaves = gb.find(name="%s.*" % ioc_name, screen_file="*autosave*")
+        assert len(autoSaves) < 2, "More than 1 autoSave element found for %s" % ioc_name
+        # These are the macros to pass to BLGuiApp_opi/*_ioc_status_embed.opi
+        macros = dict(
+            IOC=ioc_name,
+            desc=ioc_desc,
+            iocstats=len(devIocStats),
+            autosave=len(autoSaves)
+        )
+        if autoProcServControl:
+            # this must be a soft IOC
+            filename = "BLGuiApp_opi/soft_ioc_status_embed.opi"
+            # need to supply pv prefix for procServ
+            macros["PROCSERV"] = ioc_name
+        elif len(procServs) == 1:
+            # this must be a soft IOC
+            filename = "BLGuiApp_opi/soft_ioc_status_embed.opi"
+            # need to supply pv prefix for procServ
+            macros["PROCSERV"] = procServs[0].screens[0].macro_dict["P"]
+        elif len(crateMons) == 1:
+            # this must be a real IOC
+            filename = "BLGuiApp_opi/real_ioc_status_embed.opi"
+            # need to supply pv prefix for crateMon
+            macros["CMON"] = crateMons[0].screens[0].macro_dict["device"]
+        else:
+            raise AssertionError("Can't create IOC embedded object from %d procServer and %d crateMon objects" % (
+                len(procServs), len(crateMons)))
+
+        if len(autoSaves) == 1:
+            macros["AUTOSAVE"] = autoSaves[0].screens[0].macro_dict["device"]
+        # now create the embedded screen
+        synoptic = BoyScreen("boyembed", filename, macros)
+        # and add it to a Def representing the ioc
+        ioc_defs.append(gb.add_def(ioc_name, synoptic))
+
+    # we can now make our hardware status screen
+    synoptic = gb.create_screen(ioc_defs, "{{cookiecutter.domain}}-hardware")
+    gb.add_def("Hardware", synoptic)
+
+
+# Write the output
+gb.write_screens()
+gb.write_database('{{cookiecutter.domain}}.db')
+gb.write_xml('{{cookiecutter.domain}}-create-gui.xml')
+gb.write_launch_gui('{{cookiecutter.domain}}', 'synoptic.opi')
+
+# The CSS oriented BL IOC does not provide NTEMP, NFLOW etc for the modules.
+# These are required by various parts of the EDM GUI, so for compatibility
+# until the EDM GUI is retired, we generate the required PVs here and tag
+# them on the end of the database.
+
+def createN(t, p, n):
+    return "\nrecord(ao, \"%s:INFO:N%s\") {\n  field(VAL, \"%s\")\n  field(PINI, \"YES\")\n}" % (p, t, n)
+
+db_filename = "{{cookiecutter.domain}}.db"
+dbFile = open(db_filename, 'r')
+db = dbFile.read()
+dbFile.close()
+db += createN("FLOW", "{{cookiecutter.domain}}-AL-SLITS-01", 1)
+dbFile = open(db_filename, 'w')
+dbFile.write(db)
+dbFile.close()
+
+
+
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/killAllOpi
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/killAllOpi
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+cd $(dirname "$0")
+
+rm $(ls *.opi | grep -v synoptic)
+

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/synoptic.opi
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/op/opi/synoptic.opi
@@ -1,0 +1,2167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color name="Canvas" red="200" green="200" blue="200" />
+  </background_color>
+  <boy_version>5.1.0.201710301201</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>5</grid_space>
+  <height>180</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name>Synoptic</name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>false</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>1800</width>
+  <wuid>10115110:145d1627210:-7e7a</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>12</height>
+    <image_file>../vacuumSpaceApp_opi/symbol/spacenew 0.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>FEV2</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>FE{{cookiecutter.domain[2:]}}-VA-SPACE-01:STA.SEVR</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>true</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>66</width>
+    <wuid>-242ae89e:150b2d9c9fa:-7b13</wuid>
+    <x>45</x>
+    <y>10</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>40</height>
+    <image_file>../BLGuiApp_opi/images/ring 1.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>MACH</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>=('SR-DI-DCCT-01:SIGNAL' &gt; 1.0) ? 1: 0</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>40</width>
+    <wuid>57dbea6f:149f0d3c4df:-7a65</wuid>
+    <x>0</x>
+    <y>0</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <arrow_length>20</arrow_length>
+    <arrows>0</arrows>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="0" green="255" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fill_arrow>true</fill_arrow>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <height>1</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_style>0</line_style>
+    <line_width>4</line_width>
+    <name>Beam_1</name>
+    <points>
+      <point x="40" y="30" />
+      <point x="1865" y="30" />
+    </points>
+    <pv_name></pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <scripts>
+      <path pathString="../BLGuiApp_opi/beam.py" checkConnect="true" sfe="false" seoe="false">
+        <pv trig="true">loc://shouldFlip</pv>
+        <pv trig="true">=indexOf('FE{{cookiecutter.domain[2:]}}-RS-ABSB-01:STA')==1?0:"auto(FE.Absorber)"</pv>
+        <pv trig="true">=indexOf('FE{{cookiecutter.domain[2:]}}-VA-VALVE-02:STA')==1?0:"auto(FE.V2)"</pv>
+        <pv trig="true">=indexOf('FE{{cookiecutter.domain[2:]}}-PS-SHTR-02:STA')==1?0:"auto(FE.Shutter)"</pv>
+      </path>
+    </scripts>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Polyline</widget_type>
+    <width>1826</width>
+    <wuid>-2c02436b:1462304d2d9:-6dd3</wuid>
+    <x>40</x>
+    <y>30</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_6</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>11</width>
+    <wuid>-1f126ca9:14ff00fa833:-7cdd</wuid>
+    <x>555</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_7</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>11</width>
+    <wuid>-1f126ca9:14ff00fa833:-7c9d</wuid>
+    <x>925</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_7</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>11</width>
+    <wuid>-32ed6e3f:1470fd48560:-7507</wuid>
+    <x>1150</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_5</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>10</width>
+    <wuid>-32ed6e3f:1470fd48560:-7856</wuid>
+    <x>115</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>FE.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+        </macros>
+        <mode>1</mode>
+        <description>Open component screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>{{cookiecutter.domain}}-CS-FEND-01:DEVSTA.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>{{cookiecutter.domain}}-CS-FEND-01:DEVSTA:CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>true</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>true</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>5</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="13" style="0" pixels="true">Label Small</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>50</height>
+    <image_file>../BLGuiApp_opi/images/fm.png</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(FE)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>{{cookiecutter.domain}}-CS-FEND-01:DEVSTA</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>true</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>30</width>
+    <wuid>-35b9849d:150ada131ad:-7bd0</wuid>
+    <x>70</x>
+    <y>40</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>CS-CS-MSTAT-01:SCROLLM</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>286</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718f</wuid>
+    <x>10</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="12" style="0" pixels="true">Fine Print</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_1</name>
+    <precision>0</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name>SR-DI-DCCT-01:SIGNAL</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>56</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718e</wuid>
+    <x>440</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_5</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>Ring
+Current</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>35</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718d</wuid>
+    <x>400</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_6</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>Ring
+Energy</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>36</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718c</wuid>
+    <x>300</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_2</name>
+    <precision>0</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name>CS-CS-MSTAT-01:BEAMENERGY</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>56</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718b</wuid>
+    <x>340</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_7</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>Fill</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>25</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-718a</wuid>
+    <x>500</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="12" style="0" pixels="true">Fine Print</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_3</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>LI-TI-MTGEN-01:MODE</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>66</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-7189</wuid>
+    <x>530</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_8</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>Topup
+In</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>35</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-7188</wuid>
+    <x>600</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_4</name>
+    <precision>0</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name>SR-CS-FILL-01:STACOUNTDN</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>56</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-242ae89e:150b2d9c9fa:-7187</wuid>
+    <x>640</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+    <actions hook="false" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>{{cookiecutter.domain}}-vacuum.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+        </macros>
+        <mode>1</mode>
+        <description></description>
+      </action>
+      <action type="OPEN_DISPLAY">
+        <path>{{cookiecutter.domain}}-hardware.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+        </macros>
+        <mode>1</mode>
+        <description>Hardware Status</description>
+      </action>
+      <action type="OPEN_DISPLAY">
+        <path>synoptic.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+        </macros>
+        <mode>7</mode>
+        <description>Another Top Level Synoptic</description>
+      </action>
+    </actions>
+    <actions_from_pv>false</actions_from_pv>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Button: BG" red="205" green="205" blue="205" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>6</border_style>
+    <border_width>0</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Related Display: FG" red="128" green="64" blue="0" />
+    </foreground_color>
+    <height>21</height>
+    <label>Summary Screens</label>
+    <name>Summary Screens</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_down_arrow>true</show_down_arrow>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Menu Button</widget_type>
+    <width>151</width>
+    <wuid>62a577a4:150b3c1a84b:-73c6</wuid>
+    <x>1220</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>../dlsPLCApp_opi/vacValve_detail.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+          <device>FE{{cookiecutter.domain[2:]}}-VA-VALVE-02</device>
+          <DESC>FE Valve 2</DESC>
+          <valvetype>valve</valvetype>
+          <name>FV2</name>
+        </macros>
+        <mode>3</mode>
+        <description>Open detail screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name).PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name):CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <image_file>../dlsPLCApp_opi/symbol/valve 1.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(FE.V2)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>FE{{cookiecutter.domain[2:]}}-VA-VALVE-02:STA</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>20</width>
+    <wuid>-d8b8e06:1513e438012:-7c12</wuid>
+    <x>85</x>
+    <y>5</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+    <actions hook="false" hook_all="false">
+      <action type="EXECUTE_CMD">
+        <command>edm -x -noedit -eolc -m prefix=SR{{cookiecutter.domain[2:]}}-MO-,suff1=0,idname=Undulator IDBL_GapAndPhase4V4P.edl</command>
+        <command_directory>/dls_sw/prod/R3.14.12.3/support/insertionDevice/5-35/data</command_directory>
+        <wait_time>10</wait_time>
+        <description></description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Related Display: FG" red="128" green="64" blue="0" />
+    </foreground_color>
+    <height>21</height>
+    <image></image>
+    <name>Action Button_8</name>
+    <push_action_index>0</push_action_index>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <style>0</style>
+    <text>ID</text>
+    <toggle_button>false</toggle_button>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>31</width>
+    <wuid>38ff752c:1516d0dee18:-7bb0</wuid>
+    <x>705</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_5</name>
+    <precision>4</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name>SR{{cookiecutter.domain[2:]}}-MO-SERVC-01:CURRGAPD</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>86</width>
+    <wrap_words>false</wrap_words>
+    <wuid>38ff752c:1516d0dee18:-7baf</wuid>
+    <x>740</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+    <actions hook="false" hook_all="false">
+      <action type="EXECUTE_PYTHONSCRIPT">
+        <path></path>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import ScriptUtil
+from org.csstudio.opibuilder.scriptUtil import FileUtil
+import shutil
+import os
+
+filename='new.plt'
+
+source = FileUtil.workspacePathToSysPath('{{cookiecutter.domain}}/{{cookiecutter.domain}}App_opi/plots/' + filename)
+workspacepath = 'CSS/' + filename
+destination = FileUtil.workspacePathToSysPath(workspacepath)
+
+if not os.path.isfile(destination):
+    shutil.copy(source, destination)
+
+commandId="org.csstudio.trends.databrowser2.newWindow"
+ScriptUtil.executeEclipseCommand(commandId, ['plotfile', workspacepath ] )]]></scriptText>
+        <embedded>true</embedded>
+        <description>New Empty Plot</description>
+      </action>
+    </actions>
+    <actions_from_pv>false</actions_from_pv>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Button: BG" red="205" green="205" blue="205" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>6</border_style>
+    <border_width>0</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Related Display: FG" red="128" green="64" blue="0" />
+    </foreground_color>
+    <height>21</height>
+    <label>Plots</label>
+    <name>Plots</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_down_arrow>true</show_down_arrow>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Menu Button</widget_type>
+    <width>91</width>
+    <wuid>-28a80629:151918b1ce6:-7d3f</wuid>
+    <x>1120</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>../vacuumSpaceApp_opi/space_detail.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+          <device>{{cookiecutter.domain}}-VA-SPACE-01</device>
+          <desc>{{cookiecutter.domain}}-VA-SPACE-01</desc>
+          <name>SP1</name>
+        </macros>
+        <mode>3</mode>
+        <description>Open detail screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name).PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name):CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>12</height>
+    <image_file>../vacuumSpaceApp_opi/symbol/spacenew 0.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(SP1)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>{{cookiecutter.domain}}-VA-SPACE-01:STA.SEVR</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>true</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>81</width>
+    <wuid>35d7caf5:1551113bab2:-1767</wuid>
+    <x>130</x>
+    <y>10</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_10</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>11</width>
+    <wuid>49c9e8bc:156976af089:-7836</wuid>
+    <x>1365</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <border_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="Text: FG" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Label_11</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text></text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>120</width>
+    <wrap_words>false</wrap_words>
+    <wuid>153a0ff2:1571e68eb28:-7574</wuid>
+    <x>1410</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Grey 50%" red="128" green="128" blue="128" />
+    </background_color>
+    <bg_gradient_color>
+      <color name="Grey 65%" red="166" green="166" blue="166" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>true</gradient>
+    <height>116</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="169" green="165" blue="162" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle_11</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>11</width>
+    <wuid>4bd7b8c:15b385cae56:-6ef6</wuid>
+    <x>1665</x>
+    <y>25</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_13</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>PGM
+Energy</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>35</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-7c46910c:15d89b90346:-7432</wuid>
+    <x>985</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_6</name>
+    <precision>3</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name>{{cookiecutter.domain}}-OP-PGM-01:ENERGY.RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>86</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-7c46910c:15d89b90346:-7431</wuid>
+    <x>1025</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Liberation Sans" height="8" style="0" pixels="true" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_15</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>Polarisation</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>46</width>
+    <wrap_words>false</wrap_words>
+    <wuid>28a21e77:15ece3339bf:-3f0e</wuid>
+    <x>825</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Monitor BG" red="105" green="105" blue="105" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Monitor: NORMAL" red="0" green="224" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>21</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update_7</name>
+    <precision>3</precision>
+    <precision_from_pv>false</precision_from_pv>
+    <pv_name></pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules>
+      <rule name="PolarisationType" prop_id="text" out_exp="false">
+        <exp bool_exp="(pv0 &lt; 1) &amp;&amp; (pv1 &lt; 1) &amp;&amp; (pv2 &lt; 1) &amp;&amp; (pv3 &lt; 1)">
+          <value>Linear Horizontal</value>
+        </exp>
+        <pv trig="true">SR{{cookiecutter.domain[2:]}}-MO-SERVO-05:MOT.RBV</pv>
+        <pv trig="true">SR{{cookiecutter.domain[2:]}}-MO-SERVO-06:MOT.RBV</pv>
+        <pv trig="true">SR{{cookiecutter.domain[2:]}}-MO-SERVO-07:MOT.RBV</pv>
+        <pv trig="true">SR{{cookiecutter.domain[2:]}}-MO-SERVO-08:MOT.RBV</pv>
+      </rule>
+    </rules>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>true</show_units>
+    <text>Linear Vertical</text>
+    <tooltip>Polarisation from
+ID settings</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>111</width>
+    <wrap_words>false</wrap_words>
+    <wuid>28a21e77:15ece3339bf:-3f04</wuid>
+    <x>875</x>
+    <y>155</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="1" pixels="true">Default Bold</opifont.name>
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label_17</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>FE</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>41</width>
+    <wrap_words>false</wrap_words>
+    <wuid>-108c0d2e:163876f941b:-7858</wuid>
+    <x>10</x>
+    <y>115</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>../dlsPLCApp_opi/vacValve_detail.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+          <device>FE{{cookiecutter.domain[2:]}}-RS-ABSB-01</device>
+          <DESC>FE Absorber</DESC>
+          <valvetype>absorber</valvetype>
+          <name>FABS</name>
+        </macros>
+        <mode>3</mode>
+        <description>Open detail screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name).PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name):CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <image_file>../dlsPLCApp_opi/symbol/absorber 1.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(FE.Absorber)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>FE{{cookiecutter.domain[2:]}}-RS-ABSB-01:STA</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>20</width>
+    <wuid>-108c0d2e:163876f941b:-7456</wuid>
+    <x>60</x>
+    <y>5</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>../dlsPLCApp_opi/vacValve_detail.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+          <device>FE{{cookiecutter.domain[2:]}}-PS-SHTR-02</device>
+          <DESC>FE Shutter</DESC>
+          <valvetype>shutter</valvetype>
+          <name>FSHTR</name>
+        </macros>
+        <mode>3</mode>
+        <description>Open detail screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name).PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name):CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <image_file>../dlsPLCApp_opi/symbol/shutter 1.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(FE.Shutter)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>FE{{cookiecutter.domain[2:]}}-PS-SHTR-02:STA</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>20</width>
+    <wuid>-108c0d2e:163876f941b:-744b</wuid>
+    <x>110</x>
+    <y>5</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget" version="1.0.0">
+    <actions hook="true" hook_all="false">
+      <action type="OPEN_DISPLAY">
+        <path>../dlsPLCApp_opi/vacValve_detail.opi</path>
+        <macros>
+          <include_parent_macros>true</include_parent_macros>
+          <device>BL{{cookiecutter.domain[2:]}}-VA-VALVE-01</device>
+          <DESC>BL{{cookiecutter.domain[2:]}}-VA-VALVE-01</DESC>
+          <ilk0>Air Pressure</ilk0>
+          <ilk1>Initial/Run</ilk1>
+          <ilk2>PIRG-01 &amp; Ser</ilk2>
+          <ilk3>PIRG-02 &amp; Ser</ilk3>
+          <ilk4>PIRG-03 &amp; Ser</ilk4>
+          <ilk5>unused</ilk5>
+          <ilk6>unused</ilk6>
+          <ilk7>unused</ilk7>
+          <ilk8>unused</ilk8>
+          <ilk9>unused</ilk9>
+          <ilk10>unused</ilk10>
+          <ilk11>unused</ilk11>
+          <ilk12>unused</ilk12>
+          <ilk13>unused</ilk13>
+          <ilk14>unused</ilk14>
+          <ilk15>Valve Fault</ilk15>
+          <gilk0>Gauge 1</gilk0>
+          <gilk1>Gauge 2</gilk1>
+          <gilk2>Gauge 3</gilk2>
+          <gilk3>Gauge 4</gilk3>
+          <gilk4>Gauge 5</gilk4>
+          <gilk5>Gauge 6</gilk5>
+          <gilk6>unused</gilk6>
+          <gilk7>unused</gilk7>
+          <gilk8>unused</gilk8>
+          <gilk9>unused</gilk9>
+          <gilk10>unused</gilk10>
+          <gilk11>unused</gilk11>
+          <gilk12>unused</gilk12>
+          <gilk13>unused</gilk13>
+          <gilk14>unused</gilk14>
+          <gilk15>unused</gilk15>
+          <name>V1</name>
+          <valvetype>valve</valvetype>
+        </macros>
+        <mode>3</mode>
+        <description>Open detail screen</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name).PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Clear alarm status</description>
+      </action>
+      <action type="WRITE_PV">
+        <pv_name>$(pv_name):CALC.PROC</pv_name>
+        <value>1</value>
+        <timeout>5</timeout>
+        <confirm_message></confirm_message>
+        <description>Restore alarm status</description>
+      </action>
+    </actions>
+    <alarm_pulsing>false</alarm_pulsing>
+    <align_to_nearest_second>false</align_to_nearest_second>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="Canvas" red="200" green="200" blue="200" />
+    </background_color>
+    <boolean_label_position>0</boolean_label_position>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <crop_bottom>0</crop_bottom>
+    <crop_left>0</crop_left>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <degree>0</degree>
+    <enabled>true</enabled>
+    <flip_horizontal>false</flip_horizontal>
+    <flip_vertical>false</flip_vertical>
+    <font>
+      <opifont.name fontName="Liberation Sans" height="15" style="0" pixels="true">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="Black" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <image_file>../dlsPLCApp_opi/symbol/valve 1.svg</image_file>
+    <items />
+    <items_from_pv>true</items_from_pv>
+    <name>auto(V1)</name>
+    <no_animation>false</no_animation>
+    <off_color>
+      <color red="0" green="0" blue="0" />
+    </off_color>
+    <on_color>
+      <color red="0" green="0" blue="0" />
+    </on_color>
+    <permutation_matrix>
+      <row>
+        <col>1.0</col>
+        <col>0.0</col>
+      </row>
+      <row>
+        <col>0.0</col>
+        <col>1.0</col>
+      </row>
+    </permutation_matrix>
+    <pv_name>BL{{cookiecutter.domain[2:]}}-VA-VALVE-01:STA</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <stretch_to_fit>false</stretch_to_fit>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparency>false</transparency>
+    <visible>true</visible>
+    <widget_type>Multistate Symbol Monitor</widget_type>
+    <width>20</width>
+    <wuid>-108c0d2e:163876f941b:-72da</wuid>
+    <x>210</x>
+    <y>5</y>
+  </widget>
+</display>

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/Makefile
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/Makefile
@@ -1,0 +1,26 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+# In a Diamond IOC Application, build xml files from
+# database files like this
+#
+
+# The device status IOC
+PROD_IOC += {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01
+DBD += {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01.dbd
+
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_DBD += base.dbd
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_DBD += iocAdmin.dbd
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_DBD += calcSupport.dbd
+
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_SRCS_Linux += {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_registerRecordDeviceDriver.cpp
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_SRCS_Linux += {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp
+
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_LIBS += devIocStats
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_LIBS += calc
+{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+include $(TOP)/configure/RULES

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp
@@ -1,4 +1,4 @@
-/* BL11I-MO-IOC-01Main.cpp */
+/* {{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp */
 /* Author:  Marty Kraimer Date:    17MAR2000 */
 
 #include <stddef.h>

--- a/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp
+++ b/dls_ade/cookiecutter_templates/CSS_IOC/{{cookiecutter.project_name}}/{{cookiecutter.domain}}App/src/{{cookiecutter.domain}}-{{cookiecutter.technical_area}}-IOC-01Main.cpp
@@ -1,0 +1,23 @@
+/* BL11I-MO-IOC-01Main.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/dls_ade/dls_start_new_module.py
+++ b/dls_ade/dls_start_new_module.py
@@ -82,8 +82,6 @@ def _main():
 
     module_creator = get_module_creator(module_name, area, fullname)
 
-    module_creator.verify_can_create_local_module()
-
     if export_to_server:
         module_creator.verify_remote_repo()
 

--- a/dls_ade/get_module_creator.py
+++ b/dls_ade/get_module_creator.py
@@ -138,6 +138,8 @@ def get_module_creator_ioc(module_name, fullname=False):
         return mc.ModuleCreatorWithApps(module_path, area,
                                         mt.ModuleTemplateIOCBL,
                                         **template_args)
+    elif technical_area == "UI":
+        module_template_cls = mt.ModuleTemplateIOCUI
 
 
     if dash_separated:

--- a/dls_ade/get_module_creator.py
+++ b/dls_ade/get_module_creator.py
@@ -114,11 +114,17 @@ def get_module_creator_ioc(module_name, fullname=False):
 
     """
     area = "ioc"
+    module_template_cls = mt.ModuleTemplateIOC
 
     dash_separated, cols = split_ioc_module_name(module_name)
 
     domain = cols[0]
     technical_area = cols[1]
+    template_args = {
+        "domain": domain,
+        "technical_area": technical_area,
+        "ioc_number": "01"
+    }
 
     if technical_area == "BL":
         if dash_separated:
@@ -128,17 +134,18 @@ def get_module_creator_ioc(module_name, fullname=False):
             app_name = domain
             module_path = domain + "/" + technical_area
 
+        template_args["app_name"] = app_name
         return mc.ModuleCreatorWithApps(module_path, area,
                                         mt.ModuleTemplateIOCBL,
-                                        app_name=app_name)
+                                        **template_args)
 
-    module_template_cls = mt.ModuleTemplateIOC
 
     if dash_separated:
         app_name = module_name
         module_path = domain + "/" + app_name
+        template_args['app_name'] = app_name
         return mc.ModuleCreatorWithApps(module_path, area, module_template_cls,
-                                        app_name=app_name)
+                                        **template_args)
 
     if len(cols) == 3 and cols[2]:
         ioc_number = cols[2]
@@ -147,10 +154,15 @@ def get_module_creator_ioc(module_name, fullname=False):
 
     app_name = "-".join([domain, technical_area, "IOC", ioc_number])
 
+    template_args.update({
+        'app_name': app_name,
+        'ioc_number': ioc_number
+    })
+
     if fullname:
         module_path = domain + "/" + app_name
         return mc.ModuleCreatorWithApps(module_path, area, module_template_cls,
-                                        app_name=app_name)
+                                        **template_args)
     else:
         # This part is here to retain compatibility with "old-style" modules,
         # in which a single repo (or module) named "domain/technical_area"
@@ -168,14 +180,14 @@ def get_module_creator_ioc(module_name, fullname=False):
             # already exists on the remote server.
             return mc.ModuleCreatorAddAppToModule(module_path, area,
                                                   module_template_cls,
-                                                  app_name=app_name)
+                                                  **template_args)
         else:
             # Otherwise, the behaviour is exactly the same as that given
             # by the ordinary IOC class as module_path is the only thing
             # that is different
             return mc.ModuleCreatorWithApps(module_path, area,
                                             module_template_cls,
-                                            app_name=app_name)
+                                            **template_args)
 
 
 def split_ioc_module_name(module_name):

--- a/dls_ade/get_module_creator_test.py
+++ b/dls_ade/get_module_creator_test.py
@@ -93,6 +93,7 @@ class GetModuleCreatorTestPython(GetModuleCreatorTest):
         self.assertEqual(new_py_creator, "ModuleCreatorBase")
         self.mock_nmc_base.assert_called_once_with("dls_test_module", "python", self.mt_mocks['Python'])
 
+
 class GetModuleCreatorTestTools(GetModuleCreatorTest):
 
     def test_given_area_is_tools_then_module_creator_returned_with_correct_args_used(self):
@@ -127,21 +128,33 @@ class GetModuleCreatorTestIOC(GetModuleCreatorTest):
         new_ioc_creator = get_mc.get_module_creator_ioc("test-module-IOC-01")
 
         self.assertEqual(new_ioc_creator, "ModuleCreatorWithApps")
-        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-01", "ioc", self.mt_mocks['IOC'], app_name="test-module-IOC-01")
+        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-01", "ioc", self.mt_mocks['IOC'],
+                                                        app_name="test-module-IOC-01",
+                                                        domain="test",
+                                                        technical_area="module",
+                                                        ioc_number="01")
 
     def test_given_module_name_slash_separated_with_fullname_true_then_module_creator_with_apps_returned_with_correct_args_used(self):
 
         new_ioc_creator = get_mc.get_module_creator_ioc("test/module/02", fullname=True)
 
         self.assertEqual(new_ioc_creator, "ModuleCreatorWithApps")
-        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-02", "ioc", self.mt_mocks['IOC'], app_name="test-module-IOC-02")
+        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-02", "ioc", self.mt_mocks['IOC'],
+                                                        app_name="test-module-IOC-02",
+                                                        domain="test",
+                                                        technical_area="module",
+                                                        ioc_number="02")
 
     def test_given_module_name_slash_separated_with_fullname_true_but_no_ioc_number_then_module_creator_with_apps_returned_with_correct_args_used(self):
 
         new_ioc_creator = get_mc.get_module_creator_ioc("test/module", fullname=True)
 
         self.assertEqual(new_ioc_creator, "ModuleCreatorWithApps")
-        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-01", "ioc", self.mt_mocks['IOC'], app_name="test-module-IOC-01")
+        self.mock_nmc_with_apps.assert_called_once_with("test/test-module-IOC-01", "ioc", self.mt_mocks['IOC'],
+                                                        app_name="test-module-IOC-01",
+                                                        domain="test",
+                                                        technical_area="module",
+                                                        ioc_number="01")
 
     @patch('dls_ade.Server.dev_module_path', return_value="controlstest/ioc/test/module")
     def test_given_module_name_slash_separated_with_fullname_false_and_module_path_not_in_remote_repo_then_module_creator_with_apps_returned_with_correct_args_used(self, _):
@@ -153,7 +166,12 @@ class GetModuleCreatorTestIOC(GetModuleCreatorTest):
         self.assertEqual(new_ioc_creator, "ModuleCreatorWithApps")
         self.mock_is_server_repo.assert_called_once_with(
             "controlstest/ioc/test/module")
-        self.mock_nmc_with_apps.assert_called_once_with("test/module", "ioc", self.mt_mocks['IOC'], app_name="test-module-IOC-01")
+        self.mock_nmc_with_apps.assert_called_once_with("test/module", "ioc",
+                                                        self.mt_mocks['IOC'],
+                                                        app_name="test-module-IOC-01",
+                                                        domain="test",
+                                                        technical_area="module",
+                                                        ioc_number="01")
 
     @patch('dls_ade.Server.dev_module_path', return_value="controlstest/ioc/test/module")
     def test_given_module_name_slash_separated_with_fullname_false_and_module_path_in_remote_repo_then_module_creator_add_to_module_returned_with_correct_args_used(self, _):
@@ -165,7 +183,12 @@ class GetModuleCreatorTestIOC(GetModuleCreatorTest):
         self.assertEqual(new_ioc_creator, "ModuleCreatorAddApp")
         self.mock_is_server_repo.assert_called_once_with(
             "controlstest/ioc/test/module")
-        self.mock_nmc_add_app.assert_called_once_with("test/module", "ioc", self.mt_mocks['IOC'], app_name="test-module-IOC-02")
+        self.mock_nmc_add_app.assert_called_once_with("test/module", "ioc",
+                                                      self.mt_mocks['IOC'],
+                                                      app_name="test-module-IOC-02",
+                                                      domain="test",
+                                                      technical_area="module",
+                                                      ioc_number="02")
 
 
 class GetModuleCreatorTestIOCBL(GetModuleCreatorTest):
@@ -182,14 +205,22 @@ class GetModuleCreatorTestIOCBL(GetModuleCreatorTest):
         new_ioc_bl_creator = get_mc.get_module_creator_ioc("test/BL")
 
         self.assertEqual(new_ioc_bl_creator, "ModuleCreatorWithApps")
-        self.mock_nmc_with_apps.assert_called_once_with("test/BL", "ioc", self.mt_mocks['IOCBL'], app_name="test")
+        self.mock_nmc_with_apps.assert_called_once_with("test/BL", "ioc", self.mt_mocks['IOCBL'],
+                                                        app_name="test",
+                                                        domain="test",
+                                                        technical_area="BL",
+                                                        ioc_number="01")
 
     def test_given_module_name_dash_separated_then_module_creator_with_apps_returned_with_correct_args_used(self):
 
         new_ioc_bl_creator = get_mc.get_module_creator_ioc("test-BL-IOC-01", "ioc")
 
         self.assertEqual(new_ioc_bl_creator, "ModuleCreatorWithApps")
-        self.mock_nmc_with_apps.assert_called_once_with("test/test-BL-IOC-01", "ioc", self.mt_mocks['IOCBL'], app_name="test-BL-IOC-01")
+        self.mock_nmc_with_apps.assert_called_once_with("test/test-BL-IOC-01", "ioc", self.mt_mocks['IOCBL'],
+                                                        app_name="test-BL-IOC-01",
+                                                        domain="test",
+                                                        technical_area="BL",
+                                                        ioc_number="01")
 
 
 class SplitIOCModuleNameTest(unittest.TestCase):

--- a/dls_ade/get_module_creator_test.py
+++ b/dls_ade/get_module_creator_test.py
@@ -41,7 +41,8 @@ class GetModuleCreatorTest(unittest.TestCase):
             'Support',
             'Tools',
             'IOC',
-            'IOCBL'
+            'IOCBL',
+            'IOCUI'
         ]
 
         self.mt_mocks = {}
@@ -220,6 +221,27 @@ class GetModuleCreatorTestIOCBL(GetModuleCreatorTest):
                                                         app_name="test-BL-IOC-01",
                                                         domain="test",
                                                         technical_area="BL",
+                                                        ioc_number="01")
+
+
+class GetModuleCreatorTestIOCUI(GetModuleCreatorTest):
+
+    def test_given_module_name_with_invalid_separators_then_exception_raised_with_correct_message(self):
+
+        with self.assertRaises(ParsingError) as e:
+            get_mc.get_module_creator_ioc("test_UI_module")
+
+        self.assertTrue("test_UI_module" in str(e.exception))
+
+    def test_given_module_name_dash_separated_then_module_creator_with_apps_returned_with_correct_args_used(self):
+
+        new_ioc_bl_creator = get_mc.get_module_creator_ioc("test-UI-IOC-01", "ioc")
+
+        self.assertEqual(new_ioc_bl_creator, "ModuleCreatorWithApps")
+        self.mock_nmc_with_apps.assert_called_once_with("test/test-UI-IOC-01", "ioc", self.mt_mocks['IOCUI'],
+                                                        app_name="test-UI-IOC-01",
+                                                        domain="test",
+                                                        technical_area="UI",
                                                         ioc_number="01")
 
 

--- a/dls_ade/module_creator.py
+++ b/dls_ade/module_creator.py
@@ -213,7 +213,8 @@ class ModuleCreator(object):
 
         self._can_create_local_module = False
 
-        self._usermsg.info("Making clean directory structure for {}".format(self._module_path))
+        self._usermsg.info("Making clean directory structure for %s",
+                           self._module_path)
 
         os.makedirs(self.abs_module_path)
 

--- a/dls_ade/module_template.py
+++ b/dls_ade/module_template.py
@@ -6,7 +6,7 @@ from dls_ade.exceptions import ArgumentError, TemplateFolderError
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 log = logging.getLogger(__name__)
 
-MODULE_TEMPLATES = "module_templates"
+TEMPLATES_FOLDER = "module_templates"
 
 
 class ModuleTemplate(object):
@@ -82,10 +82,9 @@ class ModuleTemplate(object):
                 folder does not exist.
 
         """
-        templates_folder = MODULE_TEMPLATES
         template_path = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
-            templates_folder,
+            TEMPLATES_FOLDER,
             template_area
         )
 

--- a/dls_ade/module_template.py
+++ b/dls_ade/module_template.py
@@ -552,3 +552,43 @@ class ModuleTemplateMatlab(ModuleTemplate):
 
         return message
 
+
+class ModuleTemplateIOCUI(ModuleTemplateWithApps):
+
+    def __init__(self, template_args, additional_required_args=None):
+        super(ModuleTemplateIOCUI, self).__init__(
+                template_args,
+                additional_required_args
+        )
+
+        self.cookiecutter_template = "CSS_IOC"
+
+    def get_print_message(self):
+        module_path = self._template_args['module_path']
+        app_name = self._template_args['app_name']
+        message_dict = {
+            'RELEASE': os.path.join(module_path, "configure/RELEASE"),
+            'DbMakefile': os.path.join(
+                module_path,
+                app_name + "App/Db/Makefile"
+            ),
+            'create_gui': os.path.join(
+                module_path,
+                app_name + "App/op/opi/create_gui"
+            ),
+            'synoptic': os.path.join(
+                module_path,
+                app_name + "App/op/opi/synoptic.opi"
+            )
+        }
+
+        message = ("\nPlease now edit {RELEASE:s} to put in correct paths "
+                   "for the ioc's other technical areas and path to scripts."
+                   "\nAlso edit {DbMakefile:s} to add all database files "
+                   "from these technical areas.\nAn example set of screens"
+                   " has been created in {create_gui:s}. Please modify these."
+                   "\nThe synoptic opi in {synoptic:s} will need to be "
+                   "expanded as needed.")
+        message = message.format(**message_dict)
+
+        return message

--- a/dls_ade/module_template.py
+++ b/dls_ade/module_template.py
@@ -132,9 +132,8 @@ class ModuleTemplate(object):
                 # This stops the installer from compiling the .py files.
                 if rel_path.endswith(".py_template"):
                     rel_path = rel_path[:-9]
-                    template_files[rel_path] = contents
-                else:
-                    template_files[rel_path] = contents
+
+                template_files[rel_path] = contents
 
         return template_files
 

--- a/dls_ade/module_template.py
+++ b/dls_ade/module_template.py
@@ -217,8 +217,8 @@ class ModuleTemplate(object):
 
         The template project folder is expected to be
         {{cookiecutter.project_name}}, this name will be set to one of the
-        template args, firstly it tries using app_name if it does not exits, it
-        uses module_name otherwise CookieCutter's defaults
+        template args, firstly it tries using module_name if it does not exits, it
+        uses app_name otherwise CookieCutter's defaults
         """
         if self._cookiecutter_template_path:
             log.info("Running CookieCutter using template: %s",
@@ -228,8 +228,8 @@ class ModuleTemplate(object):
             # expects to be in the parent folder
             os.chdir('..')
 
-            project_name = self._template_args.get('app_name') \
-                or self._template_args.get('module_name')
+            project_name = self._template_args.get('module_name') \
+                or self._template_args.get('app_name')
 
             if project_name:
                 self._template_args['project_name'] = project_name
@@ -249,7 +249,7 @@ class ModuleTemplate(object):
     @property
     def cookiecutter_template(self):
         """Get CookieCutter template used
-        
+
         if none is used, it returns an empty string
         """
         return os.path.basename(self._cookiecutter_template_path)

--- a/dls_ade/module_template_test.py
+++ b/dls_ade/module_template_test.py
@@ -74,7 +74,7 @@ class ModuleTemplateSetTemplateFilesFromArea(unittest.TestCase):
 
     def setUp(self):
 
-        self.module_template_folder = mt.MODULE_TEMPLATES
+        self.module_template_folder = mt.TEMPLATES_FOLDER
 
         self.mock_os = set_up_mock(self, 'dls_ade.module_template.os')
         self.mock_get_from_folder = set_up_mock(self, 'dls_ade.module_template.ModuleTemplate._get_template_files_from_folder')

--- a/dls_ade/module_template_test.py
+++ b/dls_ade/module_template_test.py
@@ -618,3 +618,26 @@ class ModuleTemplateIOCBLPrintMessageTest(unittest.TestCase):
 
         msg = mt_obj.get_print_message()
         self.assertEqual(msg, comp_message)
+
+
+class ModuleTemplateIOCUITest(unittest.TestCase):
+
+    def setUp(self):
+        self.mt_obj = mt.ModuleTemplateIOCUI({'module_name': "test_module_name",
+                                              'module_path': "test_module_path",
+                                              'user_login': "test_login",
+                                              'app_name': "test_app_name"})
+        self.template_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            mt.COOKIECUTTER_TEMPLATES_FOLDER,
+            self.mt_obj.cookiecutter_template
+        )
+
+    @patch("dls_ade.module_template.cookiecutter")
+    def test_given_create_files_called_then_cookiecutter_called(self, mock_cookiecutter):
+        self.mt_obj.create_files()
+        self.assertEqual(mock_cookiecutter.call_args[1].get("template"),
+                         self.template_path)
+
+    def test_cookiecutter_template_folder_exists(self):
+        self.assertTrue(os.path.isdir(self.template_path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ GitPython==2.1.8
 python-ldap==2.4.41
 six==1.10.0
 pygelf==0.3.1
+cookiecutter==1.6.0
 
 # For docs
 sphinx>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     license='APACHE',
-    install_requires=['GitPython==2.1.8', 'python-ldap==2.4.41', 'six==1.10.0', 'pygelf==0.3.1'],
+    install_requires=['GitPython==2.1.8', 'python-ldap==2.4.41', 'six==1.10.0',
+                      'pygelf==0.3.1', 'cookiecutter==1.6.0'],
     packages=["dls_ade"],
     package_data={"dls_ade": additional_files},
     # define console_scripts


### PR DESCRIPTION
A few things have been done:
- Add support for CookieCutter
- Add CSS template for the UI IOCs
- Add additional template arguments

Supporting CookieCutter has many advantages:
- It uses the template language jinja2 which is very flexible
- It allows defining pre-generation and post-generation hooks, therefore all the logic belonging to a template could be in the template folder