### PR TITLE
Support release of init and Launcher from git

### DIFF
--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -182,7 +182,9 @@ def check_parsed_arguments_valid(args, parser):
             * <args.area> area not supported by git
 
     """
-    git_supported_areas = ['support', 'ioc', 'epics', 'python', 'matlab', 'tools', 'targetOS']
+    git_supported_areas = ["support", "ioc", "epics", "python", "matlab",
+                           "tools", "targetOS", "etc"]
+    etc_supported_areas = ["init", "Launcher"]
     if not args.module_name:
         parser.error("Module name not specified")
         logging.debug(args.module_name)
@@ -191,9 +193,12 @@ def check_parsed_arguments_valid(args, parser):
             (args.next_version or (args.test_only and args.commit)):
         parser.error("Module release not specified; required unless testing a "
                      "specified commit, or requesting next version.")
-    elif args.area is 'etc' and args.module_name in ['build', 'redirector']:
-        parser.error("Cannot release etc/build or etc/redirector as modules"
-                     " - use configure system instead")
+    elif args.area is "etc" and args.module_name not in etc_supported_areas:
+        parser.error(
+            "Only supported etc modules are {} - "
+            "for others you may need to use configure system instead".format(
+                etc_supported_areas)
+        )
     elif args.next_version:
         parser.error("When git is specified, version number must be provided")
     elif args.area not in git_supported_areas:

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -246,31 +246,6 @@ class TestCheckParsedOptionsValid(unittest.TestCase):
 
         self.mock_error.assert_called_once_with(expected_error_msg)
 
-    def test_given_area_option_of_etc_and_module_equals_build_then_parser_error_specifying_this(self):
-
-        self.args.module_name = "build"
-        self.args.release = "12"
-        self.args.area = "etc"
-
-        expected_error_msg = 'Cannot release etc/build or etc/redirector as'
-        expected_error_msg += ' modules - use configure system instead'
-
-        dls_release.check_parsed_arguments_valid(self.args, self.parser)
-
-        self.mock_error.assert_called_once_with(expected_error_msg)
-
-    def test_given_area_option_of_etc_and_module_equals_redirector_then_parser_error_specifying_this(self):
-        self.args.module_name = "redirector"
-        self.args.release = "12"
-        self.args.area = "etc"
-
-        expected_error_msg = 'Cannot release etc/build or etc/redirector as'
-        expected_error_msg += ' modules - use configure system instead'
-
-        dls_release.check_parsed_arguments_valid(self.args, self.parser)
-
-        self.mock_error.assert_called_once_with(expected_error_msg)
-
     def test_given_default_area_and_module_of_redirector_then_parser_error_not_called(self):
 
         self.args.module_name = "redirector"
@@ -326,13 +301,35 @@ class TestCheckParsedOptionsValid(unittest.TestCase):
 
         self.assertFalse(self.mock_error.call_count)
 
-    def test_given_git_and_etc_area_else_good_options_then_raise_error(self):
+    def test_given_git_and_etc_area_and_Launcher(self):
 
-        self.args.module_name = "module"
+        self.args.module_name = "Launcher"
         self.args.release = "version"
         self.args.area = "etc"
 
-        expected_error_message = self.args.area + " area not supported by git"
+        dls_release.check_parsed_arguments_valid(self.args, self.parser)
+
+        self.mock_error.assert_not_called()
+
+    def test_given_git_and_etc_area_and_init(self):
+
+        self.args.module_name = "init"
+        self.args.release = "version"
+        self.args.area = "etc"
+
+        dls_release.check_parsed_arguments_valid(self.args, self.parser)
+
+        self.mock_error.assert_not_called()
+
+    def test_given_git_and_etc_area_and_invalid_module_then_raise_error(self):
+
+        self.args.module_name = "redirector"
+        self.args.release = "version"
+        self.args.area = "etc"
+
+        expected_error_message = \
+            "Only supported etc modules are ['init', 'Launcher'] - " \
+            "for others you may need to use configure system instead"
 
         dls_release.check_parsed_arguments_valid(self.args, self.parser)
 

--- a/dls_ade/dlsbuild_scripts/Linux/etc.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/etc.sh
@@ -41,7 +41,6 @@ fi
 
 if [ -e Makefile ] ; then
     SysLog info "Running make"
-    make clean || ReportFailure "make clean failed"
     make       || ReportFailure "make failed"
 fi
 

--- a/dls_ade/dlsbuild_scripts/Linux/etc.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/etc.sh
@@ -29,19 +29,13 @@ build_dir=${_build_dir}
 SysLog info "Building etc in ${build_dir}"
 
 # Checkout module
-mkdir -p $build_dir              || ReportFailure "Cannot mkdir $build_dir"
 cd $build_dir                    || ReportFailure "Cannot cd to $build_dir"
-if [ ! -d $_module ]; then
-    git clone $_git_dir $_module || ReportFailure "Cannot clone $_git_dir"
-    cd $_module                  || ReportFailure "Cannot cd to $_module"
-else
-    cd $_module                  || ReportFailure "Cannot cd to $_module"
-    git pull --ff-only           || ReportFailure "Cannot pull latest version"
-fi
+cd $_module                      || ReportFailure "Cannot cd to $_module"
+git pull --ff-only               || ReportFailure "Cannot pull latest version"
 
 if [ -e Makefile ] ; then
     SysLog info "Running make"
-    make       || ReportFailure "make failed"
+    make                         || ReportFailure "make failed"
 fi
 
 SysLog info "Build complete"

--- a/dls_ade/dlsbuild_scripts/Linux/etc.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/etc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# ******************************************************************************
+# *****************************************************************************
 # 
 # Script to build a Diamond etc module
 #
@@ -13,7 +13,7 @@
 #   _epics     : The DLS_EPICS_RELEASE to use
 #   _build_dir : The parent directory in the file system in which to build the
 #                module. This does not include module or version directories.
-#   _svn_dir   : The directory in subversion where the module is located.
+#   _git_dir   : The gitolite URL where the module is located.
 #   _module    : The module name
 #   _version   : The module version
 #   _area      : The build area
@@ -29,14 +29,14 @@ build_dir=${_build_dir}
 SysLog info "Building etc in ${build_dir}"
 
 # Checkout module
-mkdir -p $build_dir                         || ReportFailure "Can not mkdir $build_dir"
-cd $build_dir                               || ReportFailure "Can not cd to $build_dir"
+mkdir -p $build_dir              || ReportFailure "Cannot mkdir $build_dir"
+cd $build_dir                    || ReportFailure "Cannot cd to $build_dir"
 if [ ! -d $_module ]; then
-    svn checkout -q $_svn_dir $_module      || ReportFailure "Can not check out  $_svn_dir"
-    cd $_module                             || ReportFailure "Can not cd to $_module"
+    git clone $_git_dir $_module || ReportFailure "Cannot clone $_git_dir"
+    cd $_module                  || ReportFailure "Cannot cd to $_module"
 else
-    cd $_module                             || ReportFailure "Can not cd to $_module"
-    svn switch $_svn_dir                    || ReportFailure "Can not switch to $_version"
+    cd $_module                  || ReportFailure "Cannot cd to $_module"
+    git pull --ff-only           || ReportFailure "Cannot pull latest version"
 fi
 
 if [ -e Makefile ] ; then


### PR DESCRIPTION
Add etc back to supported areas.
Change etc area error checking to explicitly whitelist init and Launcher only.
Update etc build script to use git.
Remove make clean step from etc build.

Fixes CGP-86: https://jira.diamond.ac.uk/browse/CGP-86