### PR TITLE
Use argparse api for tests instead of using internals.

### DIFF
--- a/dls_ade/argument_parser_test.py
+++ b/dls_ade/argument_parser_test.py
@@ -61,24 +61,36 @@ class AddModuleNameTest(unittest.TestCase):
 
     def setUp(self):
         self.parser = ArgParser("")
-        self.parser.add_module_name_arg()
 
-    def test_module_name_has_correct_attributes(self):
-        arguments = self.parser._positionals._actions[4]
-        self.assertEqual(arguments.type, str)
-        self.assertEqual(arguments.dest, 'module_name')
+    def test_arg_parser_quits_if_module_name_not_added_and_module_name_provided(self):
+        try:
+            self.parser.parse_args("-p module1".split())
+            self.fail("Parser should have quit.")
+        except SystemExit:
+            pass
+
+    def test_arg_parser_parses_module_name_correctly(self):
+        self.parser.add_module_name_arg()
+        args = self.parser.parse_args("-p module1".split())
+        self.assertEqual(args.module_name, "module1")
 
 
 class AddReleaseTest(unittest.TestCase):
 
     def setUp(self):
         self.parser = ArgParser("")
-        self.parser.add_release_arg()
 
-    def test_release_has_correct_attributes(self):
-        arguments = self.parser._positionals._actions[4]
-        self.assertEqual(arguments.type, str)
-        self.assertEqual(arguments.dest, 'release')
+    def test_arg_parser_quits_if_release_not_added_and_release_provided(self):
+        try:
+            self.parser.parse_args("-p 0-1".split())
+            self.fail("Parser should have quit.")
+        except SystemExit:
+            pass
+
+    def test_arg_parser_parses_release_correctly(self):
+        self.parser.add_release_arg()
+        args = self.parser.parse_args("-p 0-1".split())
+        self.assertEqual(args.release, "0-1")
 
 
 class AddBranchTest(unittest.TestCase):

--- a/dls_ade/dls_checkout_module_test.py
+++ b/dls_ade/dls_checkout_module_test.py
@@ -18,11 +18,17 @@ class MakeParserTest(unittest.TestCase):
         parser_mock.assert_called_once_with(
             help_msg="Checkout a specific named branch rather than the default (master)")
 
-    def test_module_name_has_correct_attributes(self):
-        arguments = self.parser._positionals._actions[5]
-        self.assertEqual(arguments.type, str)
-        self.assertEqual(arguments.nargs, '?')
-        self.assertEqual(arguments.dest, 'module_name')
+    def test_parser_has_correct_attributes(self):
+        args = self.parser.parse_args("-p module1".split())
+        self.assertEqual(args.module_name, "module1")
+        self.assertEqual(args.area, "python")
+
+    def test_parser_does_not_accept_version(self):
+        try:
+            self.parser.parse_args("-p module1 0-1".split())
+            self.fail("dls-checkout-module should not accept a version")
+        except SystemExit:
+            pass
 
 
 class CheckTechnicalAreaTest(unittest.TestCase):

--- a/dls_ade/dls_list_modules_test.py
+++ b/dls_ade/dls_list_modules_test.py
@@ -23,10 +23,10 @@ class ParserTest(unittest.TestCase):
     def setUp(self):
         self.parser = dls_list_modules.make_parser()
 
-    def test_domain_name_has_correct_attributes(self):
-        arguments = self.parser._positionals._actions[4]
-        self.assertEqual(arguments.type, str)
-        self.assertEqual(arguments.dest, 'domain_name')
+    def test_parser_understands_domain(self):
+        args = self.parser.parse_args("-i TS".split())
+        self.assertEqual(args.area, "ioc")
+        self.assertEqual(args.domain_name, "TS")
 
 
 class PrintModuleListTest(unittest.TestCase):

--- a/dls_ade/dls_logs_since_release_test.py
+++ b/dls_ade/dls_logs_since_release_test.py
@@ -19,9 +19,9 @@ class MakeParserTest(unittest.TestCase):
         parser_mock.assert_called_once_with()
 
     def test_earlier_argument_has_correct_attributes(self):
-        arguments = self.parser._positionals._actions[5]
-        self.assertEqual(arguments.type, str)
-        self.assertEqual(arguments.dest, 'releases')
+        args = self.parser.parse_args("module1 -e 0-1".split())
+        self.assertEqual(args.module_name, "module1")
+        self.assertEqual(args.earlier_release, "0-1")
 
     def test_verbose_argument_has_correct_attributes(self):
         option = self.parser._option_string_actions['-v']

--- a/dls_ade/dls_module_contacts_test.py
+++ b/dls_ade/dls_module_contacts_test.py
@@ -19,11 +19,9 @@ class MakeParserTest(unittest.TestCase):
     def setUp(self):
         self.parser = dls_module_contacts.make_parser()
 
-    def test_modules_argument_has_correct_attributes(self):
-        argument = self.parser._positionals._actions[4]
-        self.assertEqual(argument.type, str)
-        self.assertEqual(argument.dest, 'modules')
-        self.assertEqual(argument.nargs, '*')
+    def test_modules_argument_is_correctly_understood(self):
+        args = self.parser.parse_args("a b c".split())
+        self.assertEqual(args.modules, ["a", "b", "c"])
 
     def test_contact_argument_has_correct_attributes(self):
         option = self.parser._option_string_actions['-c']


### PR DESCRIPTION
There are a couple more examples that would need fixing as well.

The previous tests broke because an argument had been added to the parser, not because something wasn't working any more.

There's couple more to do but I don't have time - if you agree that it's ok can someone else fix those ones?