### PR TITLE
Tar releases in python & tool areas

### DIFF
--- a/dls_ade/argument_parser.py
+++ b/dls_ade/argument_parser.py
@@ -108,3 +108,16 @@ class ArgParser(ArgumentParser):
         """
         self.add_argument("-e", "--epics_version", action="store", type=str, dest="epics_version",
                           default=env.epicsVer(), help=help_msg)
+
+    def add_rhel_version_flag(self, help_msg="Change the rhel version, "
+                                             "default is from /etc/redhat-release "
+                                             "(can be 6 or 7)"):
+        """
+        Add rhel version flag argument with module specific help message.
+
+        Args:
+            help_msg(str): Help message relevant to module calling function
+
+        """
+        self.add_argument("-r", "--rhel_version", action="store", type=str, dest="rhel_version",
+                          default=env.rhelVer(), help=help_msg)

--- a/dls_ade/dls_environment.py
+++ b/dls_ade/dls_environment.py
@@ -28,20 +28,25 @@ except ImportError:  # Python 3
 
 log = logging.getLogger(__name__)
 
+
 class environment(object):
     """
     A class representing the epics environment of a site.
 
-    If you modify this to suit your site environment, you will be able to use any of the dls modules without
-    modification. This module has the idea of areas. An area is simply an  argument that can be passed to devArea
-    or prodArea. support and ioc must exist to use modules like the  dependency checker, others may be added. For
-    example the dls support devArea contains all support modules, and is located at ``/dls_sw/work/R3.14.12.3/support``.
-    This is the area for testing modules. There is a similar prodArea at ``/dls_sw/prod/R3.14.12.3/support`` for
-    releases. These are then used to locate the root of a particular module.
+    If you modify this to suit your site environment, you will be able to use
+    any of the dls modules without modification. This module has the idea of
+    areas. An area is simply an  argument that can be passed to devArea or
+    prodArea. support and ioc must exist to use modules like the dependency
+    checker, others may be added. For example the dls support devArea contains
+    all support modules, and is located at ``/dls_sw/work/R3.14.12.3/support``.
+    This is the area for testing modules. There is a similar prodArea at
+    ``/dls_sw/prod/R3.14.12.3/support`` for releases. These are then used to
+    locate the root of a particular module.
 
     Variables
         * epics(str): the version of epics - e.g R3.14.12.3
-        * epics_ver_re(:class:`re.RegexObject`): a useful regex for matching the version of epics
+        * epics_ver_re(:class:`re.RegexObject`): a useful regex for matching
+          the version of epics
         * areas(list): the areas that can be passed to devArea() or prodArea()
         * rhel(str): the rhel version e.g. 7
 
@@ -51,7 +56,8 @@ class environment(object):
         self.epics = None
         self.epics_ver_re = re.compile(r"R\d(\.\d+)+")
         self.rhel = None
-        self.areas = ["support", "ioc", "matlab", "python", "etc", "tools", "epics"]
+        self.areas = \
+            ["support", "ioc", "matlab", "python", "etc", "tools", "epics"]
         if epics:
             self.setEpics(epics)
         if rhel:
@@ -59,14 +65,17 @@ class environment(object):
 
     def check_epics_version(self, epics_version):
         """
-        Checks if epics version is provided. If it is, checks that it starts with 'R' and if not appends an 'R'.
-        Then checks if the epics version matches the reg ex. Then sets environment epics version.
+        Checks if epics version is provided. If it is, checks that it starts
+        with 'R' and if not appends an 'R'.
+        Then checks if the epics version matches the reg ex.
+        Then sets environment epics version.
 
         Args:
             epics_version(str): Epics version to check
 
         Raises:
-            :class:`exception.Exception`: Expected epics version like R3.14.8.2, got <epics_version>
+            :class:`exception.Exception`: Expected epics version
+            like R3.14.8.2, got <epics_version>
 
         """
         if epics_version:
@@ -75,7 +84,8 @@ class environment(object):
             if self.epics_ver_re.match(epics_version):
                 self.setEpics(epics_version)
             else:
-                raise Exception("Expected epics version like R3.14.8.2, got: " + epics_version)
+                raise Exception("Expected epics version like R3.14.8.2, got: "
+                                + epics_version)
 
     def check_rhel_version(self, rhel):
         """
@@ -91,32 +101,39 @@ class environment(object):
 
     def setEpicsFromEnv(self):
         """
-        Get epics version from the environment, and set self.epics. Set default 'R3.14.12.3' if environment
-        epics version is inaccessible.
+        Get epics version from the environment, and set self.epics. Set default
+        'R3.14.12.3' if environment epics version is inaccessible.
 
         """
         default_epics = 'R3.14.12.3'
-        self.epics = os.environ.get('DLS_EPICS_RELEASE', os.environ.get('EPICS_RELEASE', default_epics))
+        self.epics = os.environ.get('DLS_EPICS_RELEASE',
+                                    os.environ.get('EPICS_RELEASE',
+                                                   default_epics))
 
     def setRhelFromPlatform(self):
         """
-        Get rhel version from the platform, and set self.rhel. Set default '6' if platform
-        version acess fails.
+        Get rhel version from the platform, and set self.rhel.
+        Set default '6' if platform
+        version access fails.
 
         """
         default_rhel = '6'
+
+        self.rhel = default_rhel
+
         platform_dist = platform.dist()
-        try:
-            self.rhel = platform.dist()[1].split('.')[0]
-        except:
-            self.rhel = default_rhel
+        if len(platform_dist) == 3:
+            version = platform_dist[1].split(".")
+            if len(version) > 0:
+                self.rhel = platform.dist()[1].split('.')[0]
 
     def copy(self):
         """
         Return a copy of self.
 
         Returns:
-            :class:`~dls_ade.dls_environment.environment`: A copy of the environment instance
+            :class:`~dls_ade.dls_environment.environment`:
+             A copy of the environment instance
 
         """
         return environment(self.epicsVer())
@@ -156,7 +173,8 @@ class environment(object):
 
     def epicsVer(self):
         """
-        Return the version of epics from self. If it not set, try and get it from the environment.
+        Return the version of epics from self. If it not set, try and get it
+        from the environment.
         This may have a _64 suffix for 64 bit architectures.
 
         Returns:
@@ -169,7 +187,8 @@ class environment(object):
 
     def rhelVer(self):
         """
-        Return the version of rhel from self. If it not set, try and get it from the platform.
+        Return the version of rhel from self. If it not set, try and get it
+        from the platform.
 
         Returns:
             str: Rhel version
@@ -181,7 +200,8 @@ class environment(object):
 
     def epicsVerDir(self):
         """
-        Return the directory version of epics from self. If it not set, try and get it from the environment.
+        Return the directory version of epics from self. If it not set, try and
+        get it from the environment.
         This will not have a _64 suffix for 64 bit architectures.
 
         Returns:
@@ -194,7 +214,8 @@ class environment(object):
 
     def rhelVerDir(self):
         """
-        Return the distribution directory from self. If it not set, return a default.
+        Return the distribution directory from self. If it not set, return a
+        default.
 
         Returns:
             str: Distribution directory
@@ -206,27 +227,36 @@ class environment(object):
 
     def devArea(self, area="support"):
         """
-        Return the development directory for a particular area and epics version.
+        Return the development directory for a particular area and epics
+        version.
 
         Args:
             area(str): Area to generate path for
 
         Returns:
             str:
-                * `epicsVer` < R3.14 and `area` is support/ioc: /home/diamond/<EpicsVerDir>/work/<area>
-                * `epicsVer` < R3.14 and `area` is epics/etc/tools: /home/work/<area>
-                * `epicsVer` < R3.14 and `area` is matlab/python: /home/diamond/common/work/<area>
-                * `epicsVer` > R3.14 and `area` is support/ioc: /dls_sw/work/<EpicsVerDir>/<area>
-                * `epicsVer` > R3.14 and `area` is epics/etc/tools: /dls_sw/work/<area>
-                * `epicsVer` > R3.14 and `area` is matlab/python: /dls_sw/work/common/<area>
+                * `epicsVer` < R3.14 and `area` is
+                   support/ioc: /home/diamond/<EpicsVerDir>/work/<area>
+                * `epicsVer` < R3.14 and `area` is
+                   epics/etc/tools: /home/work/<area>
+                * `epicsVer` < R3.14 and `area` is matlab/python:
+                   /home/diamond/common/work/<area>
+                * `epicsVer` > R3.14 and `area` is support/ioc:
+                   /dls_sw/work/<EpicsVerDir>/<area>
+                * `epicsVer` > R3.14 and `area` is epics/etc/tools:
+                   /dls_sw/work/<area>
+                * `epicsVer` > R3.14 and `area` is matlab/python:
+                   /dls_sw/work/common/<area>
 
         """
         if area not in self.areas:
-            raise Exception("Only the following areas are supported: " + ", ".join(self.areas))
+            raise Exception("Only the following areas are supported: " +
+                            ", ".join(self.areas))
 
         if self.epicsVer() < "R3.14":
             if area in ["support", "ioc"]:
-                return os.path.join("/home", "diamond", self.epicsVerDir(), "work", area)
+                return os.path.join("/home", "diamond", self.epicsVerDir(),
+                                    "work", area)
             elif area in ["epics", "etc", "tools"]:
                 return os.path.join("/home", "work", area)
             else:
@@ -240,7 +270,8 @@ class environment(object):
             elif area in ["tools"]:
                 return os.path.join("/dls_sw", "work", area, self.rhelVerDir())
             elif area in ["python"]:
-                return os.path.join("/dls_sw", "work", "common", area, self.rhelVerDir())
+                return os.path.join("/dls_sw", "work", "common", area,
+                                    self.rhelVerDir())
             else:
                 # matlab
                 return os.path.join("/dls_sw", "work", "common", area)
@@ -255,7 +286,8 @@ class environment(object):
         Returns:
             str:
             * `area` is epics: /dls_sw/<area>
-            * Else: devArea(`area`) path with 'work' replaced by 'prod' - see devArea() doc string
+            * Else: devArea(`area`) path with 'work' replaced by 'prod' -
+              see devArea() doc string
 
         """
         if area in ["epics"]:
@@ -336,7 +368,8 @@ class environment(object):
         """
         Find the name that the module is under in svn. Very dls specific.
         """
-        output = Popen(["svn", "info", path], stdout=PIPE, stderr=STDOUT).communicate()[0]
+        output = Popen(["svn", "info", path],
+                       stdout=PIPE, stderr=STDOUT).communicate()[0]
         for line in output.splitlines():
             if line.startswith("URL:"):
                 split = line.split("/")
@@ -353,13 +386,15 @@ class environment(object):
 
     def classifyArea(self, path):
         """
-        Classify the area of a path, returning (area, work/prod/invalid, epicsVer).
+        Classify the area of a path, returning
+        (area, work/prod/invalid, epicsVer).
         
         Args:
             path(str): Path to a module or area
 
         Returns:
-            tuple: A tuple of <area>, <epics version> where <area> can be "work", "prod", or "invalid"
+            tuple: A tuple of <area>, <epics version> where <area> can be
+            "work", "prod", or "invalid"
 
         """
         for a in self.areas:
@@ -367,8 +402,7 @@ class environment(object):
                 return a, "work", self.epicsVer()
             elif path.startswith(self.prodArea(a)):
                 return a, "prod", self.epicsVer()
-            elif a in path:
-                area = a
+
         # not found, so strip epicsVer out and try again
         match = self.epics_ver_re.search(path)
         if match and match.group() != self.epicsVer():
@@ -395,10 +429,10 @@ class environment(object):
 
         """
         # classify the area
-        area, domain, epicsVer = self.classifyArea(path)
+        area, domain, epics_ver = self.classifyArea(path)
         e = self
-        if epicsVer != self.epicsVer:
-            e = self.__class__(epicsVer)
+        if epics_ver != self.epicsVer:
+            e = self.__class__(epics_ver)
         if os.path.isfile(os.path.join(path, "etc", "module.ini")):
             # try and find name from etc/module.ini
             module = self.getNameFromIni(
@@ -417,8 +451,10 @@ class environment(object):
             root = e.prodArea(area)
         else:
             root = ""
-        assert path.startswith(root), "'%s' should start with '%s'" % (path, root)
-        sections = os.path.normpath(path[len(root):]).strip(os.sep).split(os.sep)
+        assert path.startswith(root), \
+            "'%s' should start with '%s'" % (path, root)
+        sections = os.path.normpath(path[len(root):]).strip(os.sep).\
+            split(os.sep)
 
         # strip off a prefix suffix
         if sections[-1] == "prefix" and area in ["python", "tools"]:
@@ -426,18 +462,18 @@ class environment(object):
 
         # check they are the right length
         if domain == "work":        
-            if len(sections) == 1 or area in ["ioc", "tools", "python"] and len(sections) == 2:
+            if len(sections) == 1 or area in ["ioc", "tools", "python"] and \
+                    len(sections) == 2:
                 version = "work"
             else:
                 version = "invalid"
         elif domain == "prod":
-            if len(sections) == 2 or area in ["ioc", "tools", "python"] and len(sections) == 3:
+            if len(sections) == 2 or area in ["ioc", "tools", "python"] and \
+                    len(sections) == 3:
                 version = sections[-1]
                 module = os.sep.join(sections[:-1])
                 if area in ["tools", "python"]:
                     module = sections[-2]
-                else:
-                    module = os.sep.join(sections[:-1])
             else:
                 version = "invalid"
                 sections = sections[:-1]

--- a/dls_ade/dls_environment_test.py
+++ b/dls_ade/dls_environment_test.py
@@ -10,7 +10,7 @@ class EnvironmentInitTest(unittest.TestCase):
     def test_given_epics_then_set(self):
         epics = 'R3.14.8.2'
 
-        env = dls_environment.environment(epics)
+        env = dls_environment.environment(epics=epics)
 
         self.assertEqual(env.epics, epics)
 
@@ -18,6 +18,20 @@ class EnvironmentInitTest(unittest.TestCase):
         env = dls_environment.environment()
 
         self.assertEqual(env.epics, None)
+
+
+    def test_given_rhel_then_set(self):
+
+        rhel = "6"
+
+        env = dls_environment.environment(rhel=rhel)
+
+        self.assertEqual(env.rhel, rhel)
+
+    def test_not_given_rhel_then_default(self):
+
+        env = dls_environment.environment()
+        self.assertEqual(env.rhel, None)
 
     @patch('dls_ade.dls_environment.re.compile', return_value="reg_ex")
     def test_reg_exp_set(self, mock_compile):
@@ -94,6 +108,21 @@ class SetEpicsFromEnvTest(unittest.TestCase):
 
         self.assertEqual(env.epics, "R3.14.12.3")
 
+class SetRhelFromPlatformTest(unittest.TestCase):
+
+    @patch('platform.dist', return_value=["redhat","5.2","Maipo"])
+    def test_given_platform_then_set(self, _1):
+        env = dls_environment.environment()
+        env.setRhelFromPlatform()
+
+        self.assertEqual(env.rhel, "5")
+
+    @patch('platform.dist', return_value="")
+    def test_given_no_platform_then_default(self, _1):
+        env = dls_environment.environment()
+        env.setRhelFromPlatform()
+
+        self.assertEqual(env.rhel, "6")
 
 class SetEpicsTest(unittest.TestCase):
 
@@ -293,8 +322,8 @@ class DevAreaTest(unittest.TestCase):
 
     def test_given_version_more_and_tools_then_dls_work(self):
         area = 'tools'
-        expected_path = "/dls_sw/work/" + area
         env = dls_environment.environment()
+        expected_path = "/dls_sw/work/" + area + "/" + env.rhelVerDir()
         env.epics = "R3.15"
 
         path = env.devArea(area)
@@ -313,8 +342,8 @@ class DevAreaTest(unittest.TestCase):
 
     def test_given_version_more_and_python_then_dls_work_common(self):
         area = 'python'
-        expected_path = "/dls_sw/work/common/" + area
         env = dls_environment.environment()
+        expected_path = "/dls_sw/work/common/" + area + "/" + env.rhelVerDir()
         env.epics = "R3.15"
 
         path = env.devArea(area)

--- a/dls_ade/dls_tar_module.py
+++ b/dls_ade/dls_tar_module.py
@@ -53,6 +53,7 @@ def make_parser():
     parser.add_module_name_arg()
     parser.add_release_arg()
     parser.add_epics_version_flag()
+    parser.add_rhel_version_flag()
 
     parser.add_argument(
         "-u", "--untar", action="store_true", dest="untar",
@@ -123,16 +124,18 @@ def _main():
 
     check_area_archivable(args.area)
     env.check_epics_version(args.epics_version)
+    env.check_rhel_version(args.rhel_version)
     check_technical_area(args.area, args.module_name)
     
     # Check for the existence of release of this module/IOC    
     w_dir = os.path.join(env.prodArea(args.area), args.module_name)
     release_dir = os.path.join(w_dir, args.release)
     archive = release_dir + ".tar.gz"
+
     check_file_paths(release_dir, archive, args.untar)
     
     # Create build object for release
-    build = dlsbuild.ArchiveBuild(args.untar)
+    build = dlsbuild.ArchiveBuild(args.rhel_version, args.epics_version, args.untar)
     
     if args.epics_version:
         build.set_epics(args.epics_version)

--- a/dls_ade/dlsbuild.py
+++ b/dls_ade/dlsbuild.py
@@ -71,8 +71,7 @@ class Builder:
     "Base class for Diamond build server submissions"
 
     def __init__(self, bld_os, server=None, epics=None):
-        if server in SERVER_SHORTCUT.keys():
-            server = SERVER_SHORTCUT[server]
+
         assert bld_os in os_list, "Build operating system not supported"
 
         self.os = bld_os
@@ -81,6 +80,12 @@ class Builder:
         self.user = getpass.getuser()
         self.email = get_email(self.user)
         self.dls_env = environment()
+
+        if server:
+            self.dls_env.check_rhel_version(server)
+
+        if server in SERVER_SHORTCUT.keys():
+            server = SERVER_SHORTCUT[server]
 
         if epics is None:
             # if we have not specifier the epics version
@@ -306,12 +311,12 @@ class RedhatBuild(Builder):
         return Builder._script(self, params, "#!/bin/bash", "%s=%s")
 
 
-class ArchiveBuild(Builder):
+class ArchiveBuild(RedhatBuild):
     """Implements the build class for archiving or de-archiving modules. The
     constructor takes a single parameter which, if true, dearchives, otherwise
     the module will be archived."""
-    def __init__(self, untar):
-        Builder.__init__(self, "Linux")
+    def __init__(self, server, epics, untar):
+        RedhatBuild.__init__(self, server, epics)
         self.exten = ".sh"
         self.action = "unarchive" if untar else "archive"
 

--- a/dls_ade/dlsbuild_scripts/Linux/python.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/python.sh
@@ -43,7 +43,7 @@ case "$OS_VERSION" in
         INSTALL_DIR=${PREFIX}/lib/python2.6/site-packages
         ;;
     [67])
-        build_dir=${_build_dir}/RHEL${OS_VERSION}-$(uname -m)/${_module}
+        build_dir=${_build_dir}/${_module}
         PREFIX=${build_dir}/${_version}/prefix
         PYTHON=/dls_sw/prod/tools/RHEL${OS_VERSION}-$(uname -m)/defaults/bin/dls-python
         INSTALL_DIR=${PREFIX}/lib/python2.7/site-packages

--- a/dls_ade/dlsbuild_scripts/Linux/tools.sh
+++ b/dls_ade/dlsbuild_scripts/Linux/tools.sh
@@ -40,7 +40,7 @@ OS_VERSION=$(lsb_release -sr | cut -d. -f1)
 
 TOOLS_BUILD=/dls_sw/prod/etc/build/tools_build
 TOOLS_ROOT=/dls_sw/prod/tools/RHEL$OS_VERSION-$(uname -m)
-build_dir=$_build_dir/RHEL$OS_VERSION-$(uname -m)
+build_dir=$_build_dir
 
 mkdir -p $build_dir/${_module} || ReportFailure "Can not mkdir $build_dir/${_module}"
 cd $build_dir/${_module} || ReportFailure "Can not cd to $build_dir/${_module}"

--- a/dls_ade/gitserver.py
+++ b/dls_ade/gitserver.py
@@ -134,6 +134,8 @@ class GitServer(object):
         # Module is everything after area
         module = source.split('/', 2)[-1]
 
+        module = remove_git_at_end(module)
+
         repo_dir = tempfile.mkdtemp(suffix="_" + module.replace("/", "_"))
         repo = git.Repo.clone_from(os.path.join(self.clone_url,
                                                 self.get_clone_path(source)),

--- a/dls_ade/vcs_git.py
+++ b/dls_ade/vcs_git.py
@@ -340,8 +340,9 @@ class Git(BaseVCS):
         self.repo = repo
         self._version = None
 
-        if self.parent is None:
+        if self.parent is None: # required for tar-module
             self._remote_repo = ""
+            self._remote_release_repo = ""
         else:
             server_repo_path = self.parent.dev_module_path(self._module,
                                                            self.area)


### PR DESCRIPTION
dls-tar-module.py is not working for python & tools areas

These changes:
- modify the environment class function 'devArea' to return the full build path for python and tools for consistency with the other areas (i.e. including the RHELx-x86_64 folder)
- update the build scripts (python.sh and tools.sh) to no longer append the RHELx-x86_64 folder to the passed in build_dir (as it's now the full build dir)
- added additional unit tests for changes to dls_environment.py

Unexpectedly I also found I needed an extra call to remove_git_at_end in gitserver.py to stop the build name having a .git appended etc.
