### PR TITLE
Refactor main method of dls_release.py.

### DIFF
--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -423,19 +423,16 @@ def determine_version_to_release(release, next_version, releases, commit=None):
                                   commit that needs tagging in VCS, or None
 
     """
-    commit_specified = commit is not None
-    release_specified = release is not None
-
     if next_version:  # Release = next version
         version = next_version_number(releases)
         commit_to_tag = "HEAD"
-    elif not release_specified:  # Test release only of specified commit
+    elif release is None:  # Test release only of specified commit
         version = commit
         commit_to_tag = None
-    else:  # Release of version; check validity of version
+    else:  # Release of specified version
         version = release
         release_exists = release in releases
-        if not commit_specified:
+        if commit is None:  # Version and no commit: standard release
             # Release must already exist to release without a commit
             commit_to_tag = None
             if not release_exists:
@@ -443,7 +440,7 @@ def determine_version_to_release(release, next_version, releases, commit=None):
                                  "not specified.".format(release))
             else:
                 usermsg.info("Releasing existing release {}.".format(release))
-        else:  # Release and commit reference specified
+        else:  # Release and commit reference specified: commit will be tagged
             # Release must not be in use already
             if release_exists:
                 raise ValueError(

--- a/dls_ade/dls_release.py
+++ b/dls_ade/dls_release.py
@@ -221,13 +221,12 @@ def format_argument_version(arg_version):
     return arg_version.replace(".", "-")
 
 
-def next_version_number(releases, module=None):
+def next_version_number(releases):
     """
     Generates appropriate version number for an incremental release
 
     Args:
         releases(list of str): Previous release numbers
-        module(str): Name of module
 
     Returns:
         str: Incremented version number
@@ -238,9 +237,6 @@ def next_version_number(releases, module=None):
     else:
         last_release = get_last_release(releases)
         version = increment_version_number(last_release)
-        if module:
-            logging.getLogger(name="usermessages").info("Last release for {module} was {last_release}"
-                                                        .format(module=module, last_release=last_release))
     return version
 
 
@@ -402,6 +398,63 @@ def perform_test_build(build_object, local_build, vcs):
     return message, test_fail
 
 
+def determine_version_to_release(release, next_version, releases, commit=None):
+    usermsg = logging.getLogger(name="usermessages")
+    commit_specified = commit is not None
+    release_specified = release is not None
+
+    if not release_specified:
+        usermsg.info("No release specified; able to test build at {} only.". \
+                     format(commit))
+
+    if next_version:  # Release = next version
+        version = next_version_number(releases)
+        commit = "HEAD"
+        commit_specified = True
+        release_specified = True
+    elif not release_specified:  # Release = @ commit, not of release
+        version = commit
+    else:  # Release of version; check validity of version
+        release = release
+        version = release
+        release_is_valid = check_tag_is_valid(release)
+        release_exists = release in releases
+        # Commit in repository specified
+        if not commit_specified:
+            # Release must already exist to release without a commit
+            if not release_exists:
+                raise ValueError("Aborting: release {} not found and commit "
+                              "not specified.".format(release))
+            # Warn if existing release is of incorrect form
+            else:
+                usermsg.info("Releasing existing release {}.".format(release))
+                if not release_is_valid:
+                    usermsg.warning("Warning: release {} does not conform to "
+                                    "convention.".format(release))
+                    version = format_argument_version(release)
+                    if '.' in release:
+                        usermsg.warning("Release {} contains \'.\' which will"
+                                        " be replaced by \'-\' to: \'{}\'"
+                                        .format(release, version))
+        # No commit reference specified
+        else:
+            # Release must not be in use already
+            if release_exists:
+                raise ValueError(
+                    "Aborting: release {} already exists.".format(release)
+                )
+            # Specified release must be of correct form
+            if not release_is_valid:
+                raise ValueError(
+                    "Aborting: invalid release {}.".format(release)
+                )
+            usermsg.info("Releasing new release {rel} from {comm}.". \
+                         format(rel=release, comm=commit))
+
+    commit_to_release = commit if commit_specified and release_specified else None
+    return version, commit_to_release
+
+
 def _main():
 
     log = logging.getLogger(name="dls_ade")
@@ -421,80 +474,19 @@ def _main():
     source = server.dev_module_path(module, args.area)
     vcs = server.temp_clone(source)
 
-    if args.branch:
-        vcs.set_branch(args.branch)
-
-    releases = vcs.list_releases()
-
-    commit = args.commit
-    release = args.release
-    commit_specified = args.commit is not None
-    release_specified = args.release is not None
-
-    if not release_specified:
-        usermsg.info("No release specified; able to test build at {} only.".\
-                     format(commit))
-
-    if args.next_version:  # Release = next version
-        version = next_version_number(releases, module=module)
-        release = version
-        commit = "HEAD"
-        commit_specified = True
-        release_specified = True
-    elif not release_specified:  # Release = @ commit, not of release
-        version = commit
-    else:  # Release of version; check validity of version
-        release = args.release
-        version = release
-        release_is_valid = check_tag_is_valid(release)
-        release_exists = release in releases
-        # Commit in repository specified
-        if not commit_specified:
-            # Release must already exist to release without a commit
-            if not release_exists:
-                usermsg.error("Aborting: release {} not found and commit "
-                              "not specified.".format(release))
-                sys.exit(1)
-            # Warn if existing release is of incorrect form
-            else:
-                usermsg.info("Releasing existing release {}.".format(release))
-                if not release_is_valid:
-                    usermsg.warning("Warning: release {} does not conform to "
-                                    "convention.".format(release))
-                    version = format_argument_version(release)
-                    if '.' in release:
-                        usermsg.warning("Release {} contains \'.\' which will"
-                                        " be replaced by \'-\' to: \'{}\'"
-                                        .format(release, version))
-        # No commit reference specified
-        else:
-            # Release must not be in use already
-            if release_exists:
-                usermsg.error("Aborting: release {} already exists.".\
-                              format(release))
-                sys.exit(1)
-            # Specified release must be of correct form
-            else:
-                if not release_is_valid:
-                    usermsg.error("Aborting: invalid release {}.".\
-                                  format(release))
-                    sys.exit(1)
-            usermsg.info("Releasing new release {rel} from {comm}.".\
-                         format(rel=release, comm=commit))
-
-    if commit_specified and release_specified:  # Make Release if repo required
-        try:
-            usermsg.info("Making tag {ver} at {comm}".\
-                         format(ver=version, comm=commit))
-            vcs.create_new_tag_and_push(release, commit, args.message)
-        except VCSGitError as err:
-            log.exception(err)
-            usermsg.error("Aborting: {msg}".format(msg=err))
-            sys.exit(1)
-
     try:
+        if args.branch:
+            vcs.set_branch(args.branch)
+
+        releases = vcs.list_releases()
+        version, commit_to_tag = determine_version_to_release(
+            args.release, args.next_version, releases, args.commit
+        )
+        if commit_to_tag is not None:  # Make Release if repo required
+            usermsg.info("Making tag {} at {}".format(version, commit_to_tag))
+            vcs.create_new_tag_and_push(version, commit_to_tag, args.message)
         vcs.set_version(version)
-    except VCSGitError as err:
+    except (VCSGitError, ValueError) as err:
         log.exception(err)
         usermsg.error("Aborting: {msg}".format(msg=err))
         sys.exit(1)

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -830,6 +830,25 @@ class TestDetermineVersionToRelease(unittest.TestCase):
         self.assertEqual(commit_to_release, None)
 
 
+class TestDetermineVersionToRelease(unittest.TestCase):
+
+    def test_normalise_release_returns_valid_release(self):
+        old_release = '1-1'
+        new_release = dls_release.normalise_release(old_release)
+        self.assertEqual(old_release, new_release)
+
+    def test_normalise_release_replaces_dot_with_dash(self):
+        old_release = '1.1'
+        new_release = dls_release.normalise_release(old_release)
+        self.assertEqual(new_release, '1-1')
+
+    def test_normalise_release_raises_ValueError_if_release_not_valid(self):
+        with self.assertRaises(ValueError):
+            dls_release.normalise_release('1.1abc3')
+        with self.assertRaises(ValueError):
+            dls_release.normalise_release('aaa')
+
+
 class FakeOptions(object):
     def __init__(self,**kwargs):
         self.rhel_version = kwargs.get('rhel_version', None)

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -748,11 +748,12 @@ class TestPerformTestBuild(unittest.TestCase):
         self.assertEqual(test_message, expected_message)
 
 
-class TestDetermineReleaseOrCommit(unittest.TestCase):
+class TestDetermineVersionToRelease(unittest.TestCase):
 
     def setUp(self):
         self.release = '0-1'
         self.releases = ['0-1']
+        self.commit = 'abcdef'
 
     def test_determine_version_to_release_allows_invalid_version_name(self):
         # A warning is printed but the release continues.
@@ -762,13 +763,34 @@ class TestDetermineReleaseOrCommit(unittest.TestCase):
             ['invalid-release']
         )
 
+    def test_determine_version_to_release_allows_commit_but_no_version(self):
+        # A warning is printed but the release continues.
+        version, commit_to_release = dls_release.determine_version_to_release(
+            None,
+            False,
+            ['invalid-release'],
+            commit=self.commit
+        )
+        self.assertEqual(version, self.commit)
+        self.assertEqual(commit_to_release, None)
+
+    def test_determine_version_to_release_allows_commit_and_version(self):
+        version, commit_to_release = dls_release.determine_version_to_release(
+            self.release,
+            False,
+            ['invalid-release'],
+            commit=self.commit
+        )
+        self.assertEqual(version, self.release)
+        self.assertEqual(commit_to_release, self.commit)
+
     def test_determine_version_to_release_rejects_invalid_version_name_if_commit_specified(self):
         with self.assertRaises(ValueError):
             dls_release.determine_version_to_release(
                 'invalid-release',
                 False,
                 self.releases,
-                commit='abcdef'
+                commit=self.commit
             )
 
     def test_determine_version_to_release_raises_ValueError_if_release_not_in_releases(self):
@@ -778,13 +800,14 @@ class TestDetermineReleaseOrCommit(unittest.TestCase):
                 False,
                 []
             )
+
     def test_determine_version_to_release_raises_ValueError_if_commit_specified_but_tag_exists(self):
         with self.assertRaises(ValueError):
             dls_release.determine_version_to_release(
                 self.release,
                 False,
                 self.releases,
-                commit='abcdef'
+                commit=self.commit
             )
 
     def test_determine_version_to_release_returns_release_and_None_if_no_commit_specified(self):
@@ -810,9 +833,9 @@ class TestDetermineReleaseOrCommit(unittest.TestCase):
             None,
             False,
             self.releases,
-            commit='abcdef'
+            commit=self.commit
         )
-        self.assertEqual(version, 'abcdef')
+        self.assertEqual(version, self.commit)
         self.assertEqual(commit_to_release, None)
 
 

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -1,5 +1,6 @@
 #!/bin/env dls-python
 
+import mock
 import unittest
 from dls_ade import dls_release
 
@@ -747,6 +748,74 @@ class TestPerformTestBuild(unittest.TestCase):
         self.assertEqual(test_message, expected_message)
 
 
+class TestDetermineReleaseOrCommit(unittest.TestCase):
+
+    def setUp(self):
+        self.release = '0-1'
+        self.releases = ['0-1']
+
+    def test_determine_version_to_release_allows_invalid_version_name(self):
+        # A warning is printed but the release continues.
+        dls_release.determine_version_to_release(
+            'invalid-release',
+            False,
+            ['invalid-release']
+        )
+
+    def test_determine_version_to_release_rejects_invalid_version_name_if_commit_specified(self):
+        with self.assertRaises(ValueError):
+            dls_release.determine_version_to_release(
+                'invalid-release',
+                False,
+                self.releases,
+                commit='abcdef'
+            )
+
+    def test_determine_version_to_release_raises_ValueError_if_release_not_in_releases(self):
+        with self.assertRaises(ValueError):
+            dls_release.determine_version_to_release(
+                self.release,
+                False,
+                []
+            )
+    def test_determine_version_to_release_raises_ValueError_if_commit_specified_but_tag_exists(self):
+        with self.assertRaises(ValueError):
+            dls_release.determine_version_to_release(
+                self.release,
+                False,
+                self.releases,
+                commit='abcdef'
+            )
+
+    def test_determine_version_to_release_returns_release_and_None_if_no_commit_specified(self):
+        version, commit_to_release = dls_release.determine_version_to_release(
+            self.release,
+            False,
+            self.releases
+        )
+        self.assertEqual(version, '0-1')
+        self.assertEqual(commit_to_release, None)
+
+    def test_determine_version_to_release_returns_next_version_and_HEAD_if_next_version_specified(self):
+        version, commit_to_release = dls_release.determine_version_to_release(
+            None,
+            True,
+            self.releases
+        )
+        self.assertEqual(version, '0-2')
+        self.assertEqual(commit_to_release, 'HEAD')
+
+    def test_determine_version_to_release_returns_hash_if_only_commit_specified(self):
+        version, commit_to_release = dls_release.determine_version_to_release(
+            None,
+            False,
+            self.releases,
+            commit='abcdef'
+        )
+        self.assertEqual(version, 'abcdef')
+        self.assertEqual(commit_to_release, None)
+
+
 class FakeOptions(object):
     def __init__(self,**kwargs):
         self.rhel_version = kwargs.get('rhel_version', None)
@@ -784,6 +853,7 @@ class FakeVcs(object):
             #RULES=/path/to/epics/support/module/rules/x-y
         '''
         return file_contents
+
 
 if __name__ == '__main__':
 

--- a/dls_ade/dls_release_test.py
+++ b/dls_ade/dls_release_test.py
@@ -756,7 +756,7 @@ class TestDetermineVersionToRelease(unittest.TestCase):
         self.commit = 'abcdef'
 
     def test_determine_version_to_release_allows_invalid_version_name(self):
-        # A warning is printed but the release continues.
+        # This is no longer checked in this function.
         dls_release.determine_version_to_release(
             'invalid-release',
             False,
@@ -783,15 +783,6 @@ class TestDetermineVersionToRelease(unittest.TestCase):
         )
         self.assertEqual(version, self.release)
         self.assertEqual(commit_to_release, self.commit)
-
-    def test_determine_version_to_release_rejects_invalid_version_name_if_commit_specified(self):
-        with self.assertRaises(ValueError):
-            dls_release.determine_version_to_release(
-                'invalid-release',
-                False,
-                self.releases,
-                commit=self.commit
-            )
 
     def test_determine_version_to_release_raises_ValueError_if_release_not_in_releases(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Add some tests.

The `_main()` method in `dls_release.py` had grown too long and it was difficult to reason about. I have refactored it. I'm now not sure exactly what the `-c <commit>` functionality ought to be, but if I'm not wrong it will make and push a tag even for test builds. That's not necessarily wrong, but it might be a bit surprising.