### PR TITLE
Don't pretend our test coverage is higher than it is...

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [report]
 omit =
-    dls_ade/*svn*
-    dls_ade/dls_release_test.py
+    dls_ade/*_test.py
     docs/
 


### PR DESCRIPTION
We are reporting the coverage of our test modules. While there is a small case for checking coverage of test modules (are we actually using them all?) I mostly think that we're kidding ourselves that our test coverage is ~90% when it's actually ~70%.

